### PR TITLE
fix: #70

### DIFF
--- a/python/kernmlops/cli/collect.py
+++ b/python/kernmlops/cli/collect.py
@@ -51,7 +51,10 @@ def poll_instrumentation(
 
     # Poll again to clean out all buffers
     for bpf_program in bpf_programs:
-        bpf_program.poll()
+        try:
+            bpf_program.poll()
+        except Exception:
+            pass
     return_code = return_code if return_code is not None else 1
     queue.put(return_code)
     return return_code


### PR DESCRIPTION
As described in #70, I observed `collect-raw` was still failing on Ctrl-C.

This exception is triggered by an unprotected poll to osquery after the connection is already broken. The new change simply catches this exception and moves on.