### PR TITLE
fix: Timeouts throw errors in subprocess

### DIFF
--- a/config/redis_always.yaml
+++ b/config/redis_always.yaml
@@ -1,0 +1,26 @@
+---
+benchmark_config:
+  generic:
+    benchmark: redis
+    cpus: 0
+    skip_clear_page_cache: false
+    transparent_hugepages: always
+    overcommit_memory: never_check
+  redis:
+    record_count: 10000000
+    operation_count: 1000000
+    read_proportion: 0.20
+    update_proportion: 0.10
+    insert_proportion: 0.10
+    rmw_proportion: 0.10
+    scan_proportion: 0.10
+    delete_proportion: 0.30
+    request_distribution: "zipfian"
+collector_config:
+  generic:
+    poll_rate: 0.1
+    output_dir: data
+    output_graphs: false
+    hooks:
+      - mm_rss_stat
+      - process_trace

--- a/config/redis_madvise.yaml
+++ b/config/redis_madvise.yaml
@@ -1,0 +1,26 @@
+---
+benchmark_config:
+  generic:
+    benchmark: redis
+    cpus: 0
+    skip_clear_page_cache: false
+    transparent_hugepages: madvise
+    overcommit_memory: never_check
+  redis:
+    record_count: 10000000
+    operation_count: 1000000
+    read_proportion: 0.20
+    update_proportion: 0.10
+    insert_proportion: 0.10
+    rmw_proportion: 0.10
+    scan_proportion: 0.10
+    delete_proportion: 0.30
+    request_distribution: "zipfian"
+collector_config:
+  generic:
+    poll_rate: 0.1
+    output_dir: data
+    output_graphs: false
+    hooks:
+      - mm_rss_stat
+      - process_trace

--- a/config/redis_never.yaml
+++ b/config/redis_never.yaml
@@ -1,0 +1,26 @@
+---
+benchmark_config:
+  generic:
+    benchmark: redis
+    cpus: 0
+    skip_clear_page_cache: false
+    transparent_hugepages: never
+    overcommit_memory: never_check
+  redis:
+    record_count: 10000000
+    operation_count: 1000000
+    read_proportion: 0.20
+    update_proportion: 0.10
+    insert_proportion: 0.10
+    rmw_proportion: 0.10
+    scan_proportion: 0.10
+    delete_proportion: 0.30
+    request_distribution: "zipfian"
+collector_config:
+  generic:
+    poll_rate: 0.1
+    output_dir: data
+    output_graphs: false
+    hooks:
+      - mm_rss_stat
+      - process_trace

--- a/python/kernmlops/kernmlops_benchmark/redis.py
+++ b/python/kernmlops/kernmlops_benchmark/redis.py
@@ -195,8 +195,11 @@ class RedisBenchmark(Benchmark):
             return
         subprocess.run(size_redis)
         self.server.send_signal(signal.SIGINT)
-        if self.server.wait(10) is None:
+        try:
+            self.server.wait(10)
+        except subprocess.TimeoutExpired:
             self.server.terminate()
+
         self.server = None
         kill_proc = subprocess.Popen(kill_redis)
         kill_proc.wait()


### PR DESCRIPTION
- Error is caught then an attempt to terminate the process kicks in.
- Also add configs for measuring redis