### PR TITLE
feat: Add installer script for prerequisites.

### DIFF
--- a/scripts/install_prerequesites_ubuntu_24_04.sh
+++ b/scripts/install_prerequesites_ubuntu_24_04.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Add Docker's official GPG key:
+sudo apt-get update -y
+sudo apt-get install ca-certificates curl -y
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the docker repository to Apt sources:
+echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+sudo apt-get update -y
+
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin pipenv


### PR DESCRIPTION
Right now this only supports Ubuntu 24.04 for sure. Eventually we will need to expand this to a host of other linux based distributions and other versions of ubuntu.