### PR TITLE
Install PIN tool in container and run on Redis server

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -84,6 +84,15 @@ RUN apt-get update && \
 
 COPY scripts/settings.xml /etc/maven/settings.xml
 
+# Install PIN tool
+RUN mkdir -p /opt/pin && \
+    cd /opt/pin && \
+    curl -fsSL https://software.intel.com/sites/landingpage/pintool/downloads/pin-external-3.31-98869-gfa6f126a8-gcc-linux.tar.gz | tar xz && \
+    mv pin-external-3.31-98869-gfa6f126a8-gcc-linux/* . && \
+    cd source/tools/ManualExamples && \
+    make all TARGET=intel64 -j $(nproc) && \
+    ln -s /opt/pin/pin /usr/local/bin/pin
+
 # Base development image
 FROM ${BUILD_IMAGE} AS dev
 

--- a/python/kernmlops/kernmlops_benchmark/redis.py
+++ b/python/kernmlops/kernmlops_benchmark/redis.py
@@ -84,6 +84,10 @@ class RedisBenchmark(Benchmark):
 
         # start the redis server
         start_redis = [
+            "pin",
+            "-t",
+            "/opt/pin/source/tools/ManualExamples/obj-intel64/pinatrace.so",
+            "--",
             self.redis_server_name(),
             "./config/redis.conf",
         ]
@@ -92,7 +96,7 @@ class RedisBenchmark(Benchmark):
         # Wait for redis
         ping_redis = subprocess.run(["redis-cli", "ping"])
         i = 0
-        while i < 10 and ping_redis.returncode != 0:
+        while i < 30 and ping_redis.returncode != 0:
             time.sleep(1)
             ping_redis = subprocess.run(["redis-cli", "ping"])
             i+=1
@@ -122,6 +126,8 @@ class RedisBenchmark(Benchmark):
                     "redis.host=127.0.0.1",
                     "-p",
                     "redis.port=6379",
+                    "-p",
+                    "redis.timeout=60000",
                     "-p",
                     f"recordcount={self.config.record_count}",
                     "-p",
@@ -175,6 +181,8 @@ class RedisBenchmark(Benchmark):
                     "-p",
                     "redis.port=6379",
                     "-p",
+                    "redis.timeout=60000",
+                    "-p",
                     f"requestdistribution={self.config.request_distribution}",
                     "-p",
                     f"threadcount={self.config.thread_count}",
@@ -225,6 +233,8 @@ class RedisBenchmark(Benchmark):
                     "redis.host=127.0.0.1",
                     "-p",
                     "redis.port=6379",
+                    "-p",
+                    "redis.timeout=60000",
                     "-p",
                     f"requestdistribution={self.config.request_distribution}",
                     "-p",


### PR DESCRIPTION
The PIN tool is used to track memory address accesses of the Redis YCSB benchmark.

Planned additions to this PR:
* Script for parsing generated Virtual Addresses into Virtual Page Numbers + plotting
* Make "enable-pin" optional, rather than default