### PR TITLE
fix: use apt-get consistently in Dockerfile for stable interface

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,8 +7,8 @@ WORKDIR /dependencies
 
 # bcc dependencies
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update -y \
+    && apt-get install -y \
     zip \
     curl \
     build-essential \
@@ -19,17 +19,17 @@ RUN apt update -y \
     python3-setuptools \
     bpfcc-tools \
     kmod \
-    && apt clean
+    && apt-get clean
 
 # Install OSQuery
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL  https://pkg.osquery.io/deb/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/osquery.gpg
 RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/osquery.gpg] https://pkg.osquery.io/deb deb main" \
   | tee /etc/apt/sources.list.d/osquery.list > /dev/null
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update -y \
+    && apt-get install -y \
     osquery \
-    && apt clean
+    && apt-get clean
 RUN cp /opt/osquery/share/osquery/osquery.example.conf /etc/osquery/osquery.conf
 
 # Install libpfm4
@@ -37,8 +37,8 @@ RUN git clone --branch v4.13.0 https://github.com/wcohen/libpfm4.git /dependenci
 RUN make -C /dependencies/libpfm4
 
 # benchmark dependencies
-RUN apt update -y \
-    && apt install -y \
+RUN apt-get update -y \
+    && apt-get install -y \
     git \
     fakeroot \
     build-essential \
@@ -53,7 +53,7 @@ RUN apt update -y \
     nmap \
     maven \
     libgoogle-perftools-dev \
-    && apt clean
+    && apt-get clean
 
 # Install MongoDB
 RUN apt-get update && \
@@ -89,14 +89,14 @@ FROM ${BUILD_IMAGE} AS dev
 
 ARG IS_CI=true
 
-RUN apt update -y \
-  &&  apt install -y \
+RUN apt-get update -y \
+  &&  apt-get install -y \
   vim \
   pkg-config \
   bpftrace \
   zsh \
   psmisc \
-  && apt clean
+  && apt-get clean
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y \
   && echo . "$HOME/.cargo/env" > $HOME/.bashrc \


### PR DESCRIPTION
When building the docker image, these warnings pop up:
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```
Docker recommends using `apt-get` instead for a stable interface.