### PR TITLE
ref: Outputting data to special directory in another thread

### DIFF
--- a/python/kernmlops/data_collection/__init__.py
+++ b/python/kernmlops/data_collection/__init__.py
@@ -9,6 +9,7 @@ from kernmlops_config import ConfigBase
 @dataclass(frozen=True)
 class GenericCollectorConfig(ConfigBase):
     poll_rate: float = 0.5
+    output_interval: str = "1m"
     output_dir: str = "data"
     output_graphs: bool = False
     hooks: list[str] = field(default_factory=bpf.hook_names)

--- a/python/kernmlops/data_schema/__init__.py
+++ b/python/kernmlops/data_schema/__init__.py
@@ -54,11 +54,27 @@ def demote(user_id: int | None = None, group_id: int | None = None) -> Callable[
         os.setuid(user_id)
     return do_demote
 
+def get_user_group_ids() -> tuple[int, int]:
+    curr = os.getuid()
+    if curr >= 1000:
+        return (curr, curr)
+    if "UNAME" in os.environ:
+        user_id = getpwnam(os.environ["UNAME"]).pw_uid
+    else:
+        raise Exception("not enough information to get intended user")
+
+    group_id = int(os.environ.get("GID", user_id))
+
+    return (user_id, group_id)
+
+
+
 __all__ = [
     "UPTIME_TIMESTAMP",
     "collection_id_column",
     "cumulative_pma_as_pdf",
     "demote",
+    "get_user_group_ids",
     "table_types",
     "perf",
     "CollectionTable",


### PR DESCRIPTION
* Changes the output format of parquet files to allow parallel consumption
* Flips the format to make them more intuitive
* Changes the order of creating directories to happen before data exfil
* Creates a special function for grabbing the intended group_ids and user_ids
* Automatically sets permissions correctly on files

This will require follow-ups that fix various tutorials.