### PR TITLE
HPCC GUPS setup script

### DIFF
--- a/benchmark/gups/install.sh
+++ b/benchmark/gups/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+sudo apt-get update && sudo apt-get install -y \
+    build-essential \
+    openmpi-bin \
+    openmpi-doc \
+    libopenmpi-dev \
+    libopenblas-dev
+git clone https://github.com/technion-csl/gups.git
+make -C gups
+# run gups with a 1gb sized array
+cd gups && ./gups --log2_length=27


### PR DESCRIPTION
This PR adds a script to install and run HPC Challenge's GUPS benchmark with a 1GB array. Will be used by zswap tests in the future.