### PR TITLE
Quick ARM64 compatibility fix: remove amd64, bypass Makefile pull

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -24,7 +24,7 @@ RUN apt-get update -y \
 # Install OSQuery
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL  https://pkg.osquery.io/deb/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/osquery.gpg
-RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/osquery.gpg] https://pkg.osquery.io/deb deb main" \
+RUN echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/osquery.gpg] https://pkg.osquery.io/deb deb main" \
   | tee /etc/apt/sources.list.d/osquery.list > /dev/null
 RUN apt-get update -y \
     && apt-get install -y \
@@ -59,14 +59,14 @@ RUN apt-get update -y \
 RUN echo "export LIB_PFM4_DIR=/dependencies/libpfm4" >> /root/.profile
 RUN apt-get update && \
     apt-get install -y openjdk-11-jdk && \
-    echo 'export PATH=$PATH:/usr/lib/jvm/java-11-openjdk-amd64/bin' >> /root/.profile
+    echo 'export PATH=$PATH:/usr/lib/jvm/java-11-openjdk-arm64/bin' >> /root/.profile
 
 
 # Install MongoDB
 RUN apt-get update && \
     apt-get install -y gnupg curl && \
     curl -fsSL https://pgp.mongodb.com/server-6.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-6.0.gpg && \
-    echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list && \
+    echo "deb [ arch=arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list && \
     apt-get update && \
     apt-get install -y mongodb-org && \
     apt-get clean && \

--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,9 @@ provision-development:
 # Docker commands
 docker-image:
 	# Check if image already exists.
-	@docker image inspect ${DEV_IMAGE_NAME}:${VERSION} 2>&1 > /dev/null || \
-		(docker pull ${DEV_IMAGE_NAME}:${VERSION} ||\
-		${MAKE} docker-image-dependencies)
+	@docker image inspect ${DEV_IMAGE_NAME}:${VERSION} 2>&1 > /dev/null #|| \
+		#(docker pull ${DEV_IMAGE_NAME}:${VERSION} ||\
+		${MAKE} docker-image-dependencies #)
 	docker --context ${CONTAINER_CONTEXT} build \
 	--build-arg BUILD_IMAGE=${DEV_IMAGE_NAME}:${VERSION} \
 	--build-arg SRC_DIR=${CONTAINER_SRC_DIR} \


### PR DESCRIPTION
### Summary
This PR introduces a quick workaround to allow building the KernMLOps Docker image on ARM64 machines (e.g. Apple Macs with M4 chip).

### Changes
- Commented out the `docker pull` line in the Makefile near line 196 to avoid pulling x86-only image
- Replaced all instances of `amd64` with `arm64` in Dockerfile.dev

### Notes
This fix is hardcoded for arm64 and not yet generic. Submitted per Aditya Tewari's instructions.
