### PR TITLE
Quick madvise hook fix: remove premature return in hooks

### DIFF
--- a/python/kernmlops/data_collection/bpf_instrumentation/bpf/madvise.bpf.c
+++ b/python/kernmlops/data_collection/bpf_instrumentation/bpf/madvise.bpf.c
@@ -31,12 +31,14 @@ int kprobe__do_madvise(struct pt_regs* ctx, struct mm_struct* mm, unsigned long 
 int kretprobe__do_madvise(struct pt_regs* ctx) {
   u32 pid = bpf_get_current_pid_tgid();
   madvise_output_t* data;
-  if (((int)PT_REGS_RC(ctx)) != 0)
+  if (((int)PT_REGS_RC(ctx)) != 0) {
     madvise_hash.delete(&pid);
-  return 0;
-  if ((data = madvise_hash.lookup(&pid)) == NULL)
+    return 0;
+  }
+  if ((data = madvise_hash.lookup(&pid)) == NULL) {
     madvise_hash.delete(&pid);
-  return 0;
+    return 0;
+  }
   madvise_output.perf_submit(ctx, data, sizeof(madvise_output_t));
   madvise_hash.delete(&pid);
   return 0;
@@ -62,9 +64,10 @@ int kretprobe__do_vmi_align_munmap(struct pt_regs* ctx) {
   u32 pid = bpf_get_current_pid_tgid();
   if ((data = munmap_hash.lookup(&pid)) == NULL)
     return 0;
-  if (((int)PT_REGS_RC(ctx)) != 0)
+  if (((int)PT_REGS_RC(ctx)) != 0) {
     munmap_hash.delete(&pid);
-  return 0;
+    return 0;
+  }
   madvise_output.perf_submit(ctx, data, sizeof(madvise_output_t));
   munmap_hash.delete(&pid);
   return 0;

--- a/python/kernmlops/data_collection/bpf_instrumentation/madvise.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/madvise.py
@@ -40,7 +40,7 @@ ADVICE_ASSIGN_DICT = {
 class MadviseStat:
   tgid: int
   ts_ns: int
-  address: int
+  address: str
   length: int
   advice: str
 
@@ -97,7 +97,7 @@ class MadviseBPFHook(BPFProgram):
         MadviseStat(
           tgid=event.tgid,
           ts_ns=event.ts_ns,
-          address=event.address,
+          address=hex(event.address),
           length=event.length,
           advice=advice,
         )


### PR DESCRIPTION
Premature returns in madvise probe prevented madvise data from being collected. Moving returns into corresponding if statements and recording the address as a string fixed the problem.