### PR TITLE
Format python code with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,10 @@ repos:
       - id: clang-format
         args: [-i]
         exclude: module/fstore/|module/test/e2e/.*\.c$|module/test/e2e/.*\.h$
+  - repo: local
+    hooks:
+      - id: make-format
+        name: make format
+        types_or: [ python, pyi ]
+        language: system
+        entry: make format

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ lint:
 format:
 	ruff check --fix python
 	ruff check --select I --fix python
+	ruff format --exclude "*.ipynb"
 
 
 # Python commands

--- a/benchmark/zswap/parse_results.py
+++ b/benchmark/zswap/parse_results.py
@@ -7,43 +7,48 @@ import matplotlib.pyplot as plt
 
 
 def parse_results(result: dict) -> dict:
-    store_instr = {'experiment': result['experiment'], 'instructions': 0}
+    store_instr = {"experiment": result["experiment"], "instructions": 0}
 
     # Open the results file
-    with open(result['filename'], 'r') as f:
+    with open(result["filename"], "r") as f:
         for line in f:
             # Find the kernel instructions line
-            if 'instructions:k' in line:
+            if "instructions:k" in line:
                 split = line.split()
-                instr = int(split[0].replace(',', ''))
+                instr = int(split[0].replace(",", ""))
                 # Store into the dictionary
-                store_instr['instructions'] = instr
+                store_instr["instructions"] = instr
 
     return store_instr
 
+
 def main():
     mypath = "results/"
-    files = [os.path.join(dirpath,f) for (dirpath, dirnames, filenames) in os.walk(mypath) for f in filenames]
-    result_files = [f for f in files if fnmatch(f, '*results.txt')]
+    files = [
+        os.path.join(dirpath, f)
+        for (dirpath, dirnames, filenames) in os.walk(mypath)
+        for f in filenames
+    ]
+    result_files = [f for f in files if fnmatch(f, "*results.txt")]
 
     experiment_results = {}
 
     # For each file, parse the experiment name and kernel instructions
     for f in result_files:
         fname = f
-        split = f.split('/')
+        split = f.split("/")
         exp = split[1]
 
         # don't include any experiment_b results or writeback results
-        if 'experiment_b' not in exp and 'experiment_k' not in exp:
+        if "experiment_b" not in exp and "experiment_k" not in exp:
             # replace experiment_a with default
-            if exp == 'experiment_a':
-                exp += '_zswap_default'
+            if exp == "experiment_a":
+                exp += "_zswap_default"
 
-            results = {'experiment': exp, 'filename': fname}
+            results = {"experiment": exp, "filename": fname}
             instr_dir = parse_results(results)
 
-            instrs = instr_dir['instructions']
+            instrs = instr_dir["instructions"]
 
             if exp in experiment_results:
                 experiment_results[exp].append(instrs)
@@ -55,9 +60,9 @@ def main():
     for exp, values in experiment_results.items():
         avg = sum(values) / len(values)
         exp_avgs[exp] = {
-            'runs': len(values),
-            'average': f'{avg:,.0f}',
-            'raw_average': avg
+            "runs": len(values),
+            "average": f"{avg:,.0f}",
+            "raw_average": avg,
         }
 
     for exp, data in exp_avgs.items():
@@ -70,17 +75,21 @@ def main():
     # Create short names first
     exp_short_names = {}
     for exp in exp_avgs.keys():
-        short_name = re.sub(r'experiment_[a-z]_', '', exp)
+        short_name = re.sub(r"experiment_[a-z]_", "", exp)
         # Change the last underscore in short_name to equals sign
-        if '_' in short_name:
-            last_underscore_idx = short_name.rindex('_')
-            short_name = short_name[:last_underscore_idx] + '=' + short_name[last_underscore_idx+1:]
+        if "_" in short_name:
+            last_underscore_idx = short_name.rindex("_")
+            short_name = (
+                short_name[:last_underscore_idx]
+                + "="
+                + short_name[last_underscore_idx + 1 :]
+            )
         exp_short_names[exp] = short_name
 
     # Find the default experiment
     default_exp = None
     for exp in exp_avgs.keys():
-        if 'zswap_default' in exp:
+        if "zswap_default" in exp:
             default_exp = exp
             break
 
@@ -96,13 +105,13 @@ def main():
 
     # Get values in the sorted order
     short_names = [exp_short_names[exp] for exp in sorted_exps]
-    avg_instrs = [exp_avgs[exp]['raw_average'] for exp in sorted_exps]
+    avg_instrs = [exp_avgs[exp]["raw_average"] for exp in sorted_exps]
 
-    fig, ax = plt.subplots(figsize=(12,8))
+    fig, ax = plt.subplots(figsize=(12, 8))
     ax.bar(short_names, avg_instrs)
-    ax.set_ylabel('Average Kernel Instrs. per Exp. Run (trillions)', fontsize=16)
-    ax.set_xlabel('Tuned zswap Parameter Experiment', fontsize=16)
-    ax.set_title('Average Kernel Instructions Per Tuned zswap Parameter', fontsize=24)
+    ax.set_ylabel("Average Kernel Instrs. per Exp. Run (trillions)", fontsize=16)
+    ax.set_xlabel("Tuned zswap Parameter Experiment", fontsize=16)
+    ax.set_title("Average Kernel Instructions Per Tuned zswap Parameter", fontsize=24)
 
     # Convert the min value to trillions to match your data
     min_value = 6_200_000_000_000  # 6 trillion (not billion)
@@ -111,13 +120,14 @@ def main():
     ax.set_ylim(y_min, y_max)
 
     # Format y-axis to show trillions
-    ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x/1e12:.2f}T'))
+    ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f"{x / 1e12:.2f}T"))
 
-    ax.grid(axis='y', linestyle='--', alpha=0.5)
-    plt.xticks(rotation=45, ha='right')
+    ax.grid(axis="y", linestyle="--", alpha=0.5)
+    plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
-    plt.savefig('experiment_instructions_comparison.pdf')
+    plt.savefig("experiment_instructions_comparison.pdf")
     # plt.show()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/module/python/bench_ebpf_space.py
+++ b/module/python/bench_ebpf_space.py
@@ -6,13 +6,29 @@ from ctypes import c_int, c_uint32
 from bcc import BPF
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-n', action='store', type=int, dest='number', help="Number of iterations", default=1000)
-parser.add_argument('-s', action='store', type=int, dest='size', help="Size of Map", default=10)
-parser.add_argument('-d', action='store', type=int, dest='data_size', help="Data Size", default=8)
-parser.add_argument('-v', action='store', type=int, dest='debug', help="Debug Level", default=0)
-parser.add_argument('-w', action='store_true', dest='hang', help="Keep probe alive", default=False)
+parser.add_argument(
+    "-n",
+    action="store",
+    type=int,
+    dest="number",
+    help="Number of iterations",
+    default=1000,
+)
+parser.add_argument(
+    "-s", action="store", type=int, dest="size", help="Size of Map", default=10
+)
+parser.add_argument(
+    "-d", action="store", type=int, dest="data_size", help="Data Size", default=8
+)
+parser.add_argument(
+    "-v", action="store", type=int, dest="debug", help="Debug Level", default=0
+)
+parser.add_argument(
+    "-w", action="store_true", dest="hang", help="Keep probe alive", default=False
+)
 
-FIX= 1<< 32
+FIX = 1 << 32
+
 
 def simplerand(rand: list[int]) -> (int, list[int]):
     w = rand[0]
@@ -29,11 +45,13 @@ def simplerand(rand: list[int]) -> (int, list[int]):
     w ^= t
     return (w, [w, x, y, z])
 
+
 def write(data, fd=3):
     try:
-        os.write(fd, bytes(data, 'ascii'))
+        os.write(fd, bytes(data, "ascii"))
     except OSError:
         return -1
+
 
 args = parser.parse_args()
 
@@ -113,7 +131,7 @@ int probe(struct pt_regs *ctx) {{
 bpf_ctx = BPF(text=txt, debug=args.debug)
 
 on = bpf_ctx["on"]
-on[c_int(0)]=c_int(1)
+on[c_int(0)] = c_int(1)
 
 rand = [1, 4, 7, 13]
 array = bpf_ctx["array"]
@@ -125,19 +143,24 @@ for i in range(0, args.size):
         arr[j] = val
     array[c_uint32(i)] = arr
 
-bpf_ctx.attach_kprobe(event='do_nanosleep', fn_name="probe")
+bpf_ctx.attach_kprobe(event="do_nanosleep", fn_name="probe")
 
 ready = True
+
 
 def print_event(cpu, data, size):
     output = bpf_ctx["events"].event(data)
     time.sleep(0.001)
-    write("get_iterations %ld\tmap_size %ld\tvalue_size %d\tTime(ns) %ld\n" % (args.number, args.size, args.data_size, output.ts))
+    write(
+        "get_iterations %ld\tmap_size %ld\tvalue_size %d\tTime(ns) %ld\n"
+        % (args.number, args.size, args.data_size, output.ts)
+    )
     return -1
+
 
 bpf_ctx["events"].open_perf_buffer(print_event)
 
-on[c_int(0)]=c_int(0)
+on[c_int(0)] = c_int(0)
 while ready:
     bpf_ctx.perf_buffer_poll()
     if not args.hang:

--- a/module/scripts/graph.py
+++ b/module/scripts/graph.py
@@ -25,61 +25,81 @@ class GraphType(Enum):
         except KeyError:
             raise ValueError()
 
+
 parser = argparse.ArgumentParser()
-parser.add_argument('-t', action='store', dest="gtitle", help="Graph Title", required=True)
-parser.add_argument('-x', action='store', dest="xlabel", help="XAxis Label", required=True)
-parser.add_argument('-y', action='store', dest="ylabel", help="YAxis Label", required=True)
-parser.add_argument('-g', action='store', dest="groups", help="Group ARows", default=1, type=int)
-parser.add_argument('--horizon', action='store_true', dest="horizon")
-parser.add_argument('-v', action='store_true', dest="verbose")
-parser.add_argument('--no-horizon', dest='horizon', action='store_false')
+parser.add_argument(
+    "-t", action="store", dest="gtitle", help="Graph Title", required=True
+)
+parser.add_argument(
+    "-x", action="store", dest="xlabel", help="XAxis Label", required=True
+)
+parser.add_argument(
+    "-y", action="store", dest="ylabel", help="YAxis Label", required=True
+)
+parser.add_argument(
+    "-g", action="store", dest="groups", help="Group ARows", default=1, type=int
+)
+parser.add_argument("--horizon", action="store_true", dest="horizon")
+parser.add_argument("-v", action="store_true", dest="verbose")
+parser.add_argument("--no-horizon", dest="horizon", action="store_false")
 parser.set_defaults(horizon=False)
-parser.add_argument('-o', action='store', dest="ouputf", help="Output FileN", required=True)
-parser.add_argument('-i', action='store', dest="inputf", help="Input FileN", default="")
-parser.add_argument('-p', dest='gtype', help="Graph Type", type=lambda val: GraphType[val], choices=list(GraphType), default = "bar")
-parser.add_argument('-l', dest='log', help="Data Access Log Scale", action='store_true')
+parser.add_argument(
+    "-o", action="store", dest="ouputf", help="Output FileN", required=True
+)
+parser.add_argument("-i", action="store", dest="inputf", help="Input FileN", default="")
+parser.add_argument(
+    "-p",
+    dest="gtype",
+    help="Graph Type",
+    type=lambda val: GraphType[val],
+    choices=list(GraphType),
+    default="bar",
+)
+parser.add_argument("-l", dest="log", help="Data Access Log Scale", action="store_true")
 
-new_color_cycle = cycler(color=['cyan', 'green', 'orange', 'purple', 'magenta'])
+new_color_cycle = cycler(color=["cyan", "green", "orange", "purple", "magenta"])
 
-plt.rcParams['axes.prop_cycle'] = new_color_cycle
+plt.rcParams["axes.prop_cycle"] = new_color_cycle
 SMALL_SIZE = 16
 MEDIUM_SIZE = 20
 LARGE_SIZE = 24
-plt.rc('font', size=SMALL_SIZE)          # controls default text sizes
-plt.rc('axes', titlesize=LARGE_SIZE)     # fontsize of the axes title
-plt.rc('axes', labelsize=MEDIUM_SIZE)    # fontsize of the x and y labels
-plt.rc('xtick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
-plt.rc('ytick', labelsize=SMALL_SIZE)    # fontsize of the tick labels
-plt.rc('legend', fontsize=SMALL_SIZE)    # legend fontsize
-plt.rc('figure', titlesize=LARGE_SIZE)  # fontsize of the figure title
+plt.rc("font", size=SMALL_SIZE)  # controls default text sizes
+plt.rc("axes", titlesize=LARGE_SIZE)  # fontsize of the axes title
+plt.rc("axes", labelsize=MEDIUM_SIZE)  # fontsize of the x and y labels
+plt.rc("xtick", labelsize=SMALL_SIZE)  # fontsize of the tick labels
+plt.rc("ytick", labelsize=SMALL_SIZE)  # fontsize of the tick labels
+plt.rc("legend", fontsize=SMALL_SIZE)  # legend fontsize
+plt.rc("figure", titlesize=LARGE_SIZE)  # fontsize of the figure title
 
 verbose = False
 
+
 def parse_bar_input(inputf, groups: int):
-  xaxis = []
-  yaxis = []
-  eaxis = []
-  group_label = []
+    xaxis = []
+    yaxis = []
+    eaxis = []
+    group_label = []
 
-  for i in range (0,groups):
-    yaxis.append([])
-    eaxis.append([])
+    for i in range(0, groups):
+        yaxis.append([])
+        eaxis.append([])
 
-  for line in inputf.readlines():
-    broken_line = re.split(r'\s+', line.rstrip())
-    if verbose:
-        print(broken_line)
-    if groups > 1 and group_label == []:
-      group_label = broken_line
-      continue
-    for i in range(0,groups) :
-      yaxis[i].append(float(broken_line[i]))
-      if len(broken_line) > groups + 1 +i:
-       eaxis[i].append(float(broken_line[groups + 1 + i]))
-      else :
-        eaxis[i].append(0)
-    xaxis.append(broken_line[groups])
-    return (xaxis, yaxis, eaxis, group_label)
+    for line in inputf.readlines():
+        broken_line = re.split(r"\s+", line.rstrip())
+        if verbose:
+            print(broken_line)
+        if groups > 1 and group_label == []:
+            group_label = broken_line
+            continue
+        for i in range(0, groups):
+            yaxis[i].append(float(broken_line[i]))
+            if len(broken_line) > groups + 1 + i:
+                eaxis[i].append(float(broken_line[groups + 1 + i]))
+            else:
+                eaxis[i].append(0)
+        xaxis.append(broken_line[groups])
+        return (xaxis, yaxis, eaxis, group_label)
+
 
 def open_data_file(valFile: Path) -> [float]:
     data = []
@@ -88,31 +108,34 @@ def open_data_file(valFile: Path) -> [float]:
             data.append(float(line.rstrip()))
     return data
 
+
 def parse_box_input(inputf, groups: int):
     xaxis = []
     yaxis = []
     eaxis = []
     group_label = []
-    for i in range (0,groups):
+    for i in range(0, groups):
         yaxis.append([])
         eaxis.append([])
 
     for line in inputf.readlines():
-        broken_line = re.split(r'\s+', line.rstrip())
+        broken_line = re.split(r"\s+", line.rstrip())
         if groups > 1 and group_label == []:
             group_label = broken_line
             continue
-        for i in range(0,groups) :
+        for i in range(0, groups):
             yaxis[i].append(open_data_file(Path(broken_line[i])))
             eaxis[i].append(0)
         xaxis.append(broken_line[groups])
     return (xaxis, yaxis, eaxis, group_label)
 
+
 def set_box_color(bp, color):
-    plt.setp(bp['boxes'], color=color)
-    plt.setp(bp['whiskers'], color=color)
-    plt.setp(bp['caps'], color=color)
-    plt.setp(bp['medians'], color=color)
+    plt.setp(bp["boxes"], color=color)
+    plt.setp(bp["whiskers"], color=color)
+    plt.setp(bp["caps"], color=color)
+    plt.setp(bp["medians"], color=color)
+
 
 """
 bar type graphs:
@@ -130,9 +153,13 @@ box type graphs:
     pathG0Y0s pathG1Y0s pathG2Y0s
     pathG0Y1s pathG1Y1s pathG2Y1s
 """
-def graph(gtitle, xlabel, ylabel, inputf, ouputf, groups, horizon, gtype: GraphType, log: bool):
-    _ = plt.figure(figsize=(10,7))
-    #ax = fig.add_axes([0,0,1,1])
+
+
+def graph(
+    gtitle, xlabel, ylabel, inputf, ouputf, groups, horizon, gtype: GraphType, log: bool
+):
+    _ = plt.figure(figsize=(10, 7))
+    # ax = fig.add_axes([0,0,1,1])
     xaxis, yaxis, eaxis, group_label = ([], [], [], [])
 
     if verbose:
@@ -149,21 +176,23 @@ def graph(gtitle, xlabel, ylabel, inputf, ouputf, groups, horizon, gtype: GraphT
         print(xaxis)
 
     width_orig = 0.8
-    width = width_orig/groups
-    if group_label == [] :
+    width = width_orig / groups
+    if group_label == []:
         group_label.append("")
     ind = np.arange(len(yaxis[0]))
-    for i,color in zip(range(0, groups), new_color_cycle):
-        pos = ind + (-(groups -1)/2.0 +i)*width
+    for i, color in zip(range(0, groups), new_color_cycle):
+        pos = ind + (-(groups - 1) / 2.0 + i) * width
         if verbose:
             print(pos)
         if gtype is GraphType.bar:
             if horizon:
-              plt.barh(pos, yaxis[i], width, yerr=eaxis[i], label=group_label[i])
+                plt.barh(pos, yaxis[i], width, yerr=eaxis[i], label=group_label[i])
             else:
-              plt.bar(pos, yaxis[i], width, yerr=eaxis[i], label=group_label[i])
+                plt.bar(pos, yaxis[i], width, yerr=eaxis[i], label=group_label[i])
         elif gtype is GraphType.box:
-            bp = plt.boxplot(yaxis[i], positions=pos, widths=width, label=group_label[i])
+            bp = plt.boxplot(
+                yaxis[i], positions=pos, widths=width, label=group_label[i]
+            )
             set_box_color(bp, color["color"])
 
     if horizon:
@@ -181,14 +210,24 @@ def graph(gtitle, xlabel, ylabel, inputf, ouputf, groups, horizon, gtype: GraphT
         if log:
             plt.yscale("log")
     if groups > 1:
-        plt.legend(bbox_to_anchor=(1,.5),loc='center left')
-    plt.savefig(ouputf, bbox_inches='tight')
+        plt.legend(bbox_to_anchor=(1, 0.5), loc="center left")
+    plt.savefig(ouputf, bbox_inches="tight")
 
 
 if __name__ == "__main__":
-  args = parser.parse_args()
-  inputf = sys.stdin
-  verbose = args.verbose
-  if args.inputf != "" or args.inputf is None:
-    inputf = open(args.inputf)
-  graph(args.gtitle,args.xlabel,args.ylabel,inputf,args.ouputf,args.groups,args.horizon,args.gtype, args.log)
+    args = parser.parse_args()
+    inputf = sys.stdin
+    verbose = args.verbose
+    if args.inputf != "" or args.inputf is None:
+        inputf = open(args.inputf)
+    graph(
+        args.gtitle,
+        args.xlabel,
+        args.ylabel,
+        inputf,
+        args.ouputf,
+        args.groups,
+        args.horizon,
+        args.gtype,
+        args.log,
+    )

--- a/python/kernmlops/analysis/bloat.py
+++ b/python/kernmlops/analysis/bloat.py
@@ -4,13 +4,13 @@ import polars as pl
 from plotnine import aes, geom_point, geom_step, ggplot, labs
 
 
-def filter_process_trace(process_trace_df: pl.DataFrame) -> pl.DataFrame :
+def filter_process_trace(process_trace_df: pl.DataFrame) -> pl.DataFrame:
     df = process_trace_df
     # Filter just the processes
     df = df.filter(pl.col("tgid") == pl.col("pid")).drop("collection_id")
 
     # Find the last name of each process
-    start_df = df.sort(pl.col("ts_ns"), descending = True)
+    start_df = df.sort(pl.col("ts_ns"), descending=True)
     helper_dict = {}
     for row in start_df.iter_rows():
         pid = row[0]
@@ -20,16 +20,33 @@ def filter_process_trace(process_trace_df: pl.DataFrame) -> pl.DataFrame :
         helper_dict[pid] = comm
 
     # Separate the start and end
-    full_df = start_df.with_columns(pl.col("pid").map_elements(lambda x : helper_dict.get(x, ""), return_dtype=pl.String).alias("full_name"))
+    full_df = start_df.with_columns(
+        pl.col("pid")
+        .map_elements(lambda x: helper_dict.get(x, ""), return_dtype=pl.String)
+        .alias("full_name")
+    )
     full_df = full_df.drop(["tgid", "name"])
-    start_df = full_df.filter(pl.col("cap_type") == "start").rename({"ts_ns": "start_ns"}).drop("cap_type")
-    end_df = full_df.filter(pl.col("cap_type") == "end").rename({"ts_ns": "end_ns"}).drop(["cap_type", "full_name"])
+    start_df = (
+        full_df.filter(pl.col("cap_type") == "start")
+        .rename({"ts_ns": "start_ns"})
+        .drop("cap_type")
+    )
+    end_df = (
+        full_df.filter(pl.col("cap_type") == "end")
+        .rename({"ts_ns": "end_ns"})
+        .drop(["cap_type", "full_name"])
+    )
 
     # Join them to get the process table
     combined_df = start_df.join(end_df, "pid")
-    return combined_df.with_columns((pl.col("end_ns") - pl.col("start_ns")).alias("duration"))
+    return combined_df.with_columns(
+        (pl.col("end_ns") - pl.col("start_ns")).alias("duration")
+    )
 
-def process_trace_start_end_ts(process_trace_df: pl.DataFrame, proc_name: str, index: int) -> tuple[int, int, int]:
+
+def process_trace_start_end_ts(
+    process_trace_df: pl.DataFrame, proc_name: str, index: int
+) -> tuple[int, int, int]:
     trace_df = filter_process_trace(process_trace_df).sort(pl.col("start_ns"))
     df = trace_df.filter(pl.col("full_name") == proc_name)
     # print(df)
@@ -39,35 +56,45 @@ def process_trace_start_end_ts(process_trace_df: pl.DataFrame, proc_name: str, i
     end_ns = df["end_ns"][0]
     return pid, start_ns, end_ns
 
+
 def clean_rss_pid(rss_df: pl.DataFrame, pid: int) -> pl.DataFrame:
     df = rss_df.drop(["pid", "collection_id"]).sort(pl.col("ts_ns"))
     df = df.filter(pl.col("tgid") == pid)
-    df = df.with_columns(pl.when(pl.col("member") == "MM_FILEPAGES")
-                     .then(pl.col("count"))
-                     .otherwise(None)
-                     .fill_null(strategy="forward")
-                     .fill_null(strategy="backward")
-                     .alias("file"))
-    df = df.with_columns(pl.when(pl.col("member") == "MM_ANONPAGES")
-                     .then(pl.col("count"))
-                     .otherwise(None)
-                     .fill_null(strategy="forward")
-                     .fill_null(strategy="backward")
-                     .alias("anon"))
-    df = df.with_columns(pl.when(pl.col("member") == "MM_SWAPENTS")
-                     .then(pl.col("count"))
-                     .otherwise(None)
-                     .fill_null(strategy="forward")
-                     .fill_null(strategy="backward")
-                     .alias("swap"))
+    df = df.with_columns(
+        pl.when(pl.col("member") == "MM_FILEPAGES")
+        .then(pl.col("count"))
+        .otherwise(None)
+        .fill_null(strategy="forward")
+        .fill_null(strategy="backward")
+        .alias("file")
+    )
+    df = df.with_columns(
+        pl.when(pl.col("member") == "MM_ANONPAGES")
+        .then(pl.col("count"))
+        .otherwise(None)
+        .fill_null(strategy="forward")
+        .fill_null(strategy="backward")
+        .alias("anon")
+    )
+    df = df.with_columns(
+        pl.when(pl.col("member") == "MM_SWAPENTS")
+        .then(pl.col("count"))
+        .otherwise(None)
+        .fill_null(strategy="forward")
+        .fill_null(strategy="backward")
+        .alias("swap")
+    )
     df = df.drop(["member", "count"])
-    zero_df = pl.DataFrame({"tgid": pid, "ts_ns" : -1, "file" : 0, "anon": 0, "swap": 0})
+    zero_df = pl.DataFrame({"tgid": pid, "ts_ns": -1, "file": 0, "anon": 0, "swap": 0})
     df = pl.concat([df, zero_df]).sort("ts_ns")
     df = df.fill_null(strategy="forward")
     df = df.filter(pl.col("ts_ns") >= 0)
-    df = df.with_columns((pl.col("file") + pl.col("anon") + pl.col("swap")).alias("count"))
+    df = df.with_columns(
+        (pl.col("file") + pl.col("anon") + pl.col("swap")).alias("count")
+    )
     df = df.drop(["file", "anon", "swap"])
     return df
+
 
 def filter_rss_with_ts(rss_trace_df: pl.DataFrame, start: int, end: int):
     # print(start, end)
@@ -76,45 +103,73 @@ def filter_rss_with_ts(rss_trace_df: pl.DataFrame, start: int, end: int):
         new_frame_dict[column_name] = [None, None]
     new_frame_dict["ts_ns"] = [start, end]
     df = rss_trace_df.vstack(pl.DataFrame(new_frame_dict))
-    df = df.sort(pl.col("ts_ns")).fill_null(strategy="forward").fill_null(strategy="backward")
-    return df.filter(pl.col("ts_ns").is_between(start, end, closed='both'))
+    df = (
+        df.sort(pl.col("ts_ns"))
+        .fill_null(strategy="forward")
+        .fill_null(strategy="backward")
+    )
+    return df.filter(pl.col("ts_ns").is_between(start, end, closed="both"))
 
-def get_proper_rss(proc_path: list[Path], rss_path: list[Path],
-                   rss_name: str, rss_ind: int,
-                   runner_name: str, runner_ind: int, tag:str) -> pl.DataFrame:
+
+def get_proper_rss(
+    proc_path: list[Path],
+    rss_path: list[Path],
+    rss_name: str,
+    rss_ind: int,
+    runner_name: str,
+    runner_ind: int,
+    tag: str,
+) -> pl.DataFrame:
     proc_trace_df = pl.read_parquet(proc_path, allow_missing_columns=True)
     rss_df = pl.read_parquet(rss_path, allow_missing_columns=True)
 
     _, start, end = process_trace_start_end_ts(proc_trace_df, runner_name, runner_ind)
     pid, _, _ = process_trace_start_end_ts(proc_trace_df, rss_name, rss_ind)
     clean_rss_df = filter_rss_with_ts(clean_rss_pid(rss_df, pid), start, end)
-    return clean_rss_df.with_columns((pl.col("ts_ns") - pl.min("ts_ns")).alias("norm_ts_ns")).with_columns(pl.lit(tag).alias('policy'))
+    return clean_rss_df.with_columns(
+        (pl.col("ts_ns") - pl.min("ts_ns")).alias("norm_ts_ns")
+    ).with_columns(pl.lit(tag).alias("policy"))
 
-def export_graph_data_frame(inputs: list[tuple[str, dict[str, list[Path]]]],
-                            proc_tag: str, proc_ind: int,
-                            time_proc_tag: str, time_proc_index: int) -> pl.DataFrame:
+
+def export_graph_data_frame(
+    inputs: list[tuple[str, dict[str, list[Path]]]],
+    proc_tag: str,
+    proc_ind: int,
+    time_proc_tag: str,
+    time_proc_index: int,
+) -> pl.DataFrame:
     df = pl.DataFrame()
-    for (tag, filedict) in inputs:
-        append_df = get_proper_rss(filedict["process_trace"],
-                                   filedict["mm_rss_stat"],
-                                   proc_tag, proc_ind,
-                                   time_proc_tag,
-                                   time_proc_index,
-                                   tag).drop(["tgid", "ts_ns"])
+    for tag, filedict in inputs:
+        append_df = get_proper_rss(
+            filedict["process_trace"],
+            filedict["mm_rss_stat"],
+            proc_tag,
+            proc_ind,
+            time_proc_tag,
+            time_proc_index,
+            tag,
+        ).drop(["tgid", "ts_ns"])
         df = pl.concat([df, append_df])
-    df = df.with_columns((pl.col("norm_ts_ns") / (10**9)/ 60).alias("norm_ts_mins"))
+    df = df.with_columns((pl.col("norm_ts_ns") / (10**9) / 60).alias("norm_ts_mins"))
     return df
 
-def create_graph(inputs: list[tuple[str, dict[str, list[Path]]]],
-                 proc_tag: str, proc_ind: int,
-                 time_proc_tag: str, time_proc_index: int, title: str) -> ggplot:
-    df = export_graph_data_frame(inputs, proc_tag, proc_ind, time_proc_tag, time_proc_index)
-    plt0 = (ggplot(df)
-            + aes("norm_ts_mins", y="count", colour="policy")
-            + geom_point()
-            + geom_step()
-            + labs(x="Time (mins)",
-                   y="4kB Pages",
-                   title=title)
-           )
+
+def create_graph(
+    inputs: list[tuple[str, dict[str, list[Path]]]],
+    proc_tag: str,
+    proc_ind: int,
+    time_proc_tag: str,
+    time_proc_index: int,
+    title: str,
+) -> ggplot:
+    df = export_graph_data_frame(
+        inputs, proc_tag, proc_ind, time_proc_tag, time_proc_index
+    )
+    plt0 = (
+        ggplot(df)
+        + aes("norm_ts_mins", y="count", colour="policy")
+        + geom_point()
+        + geom_step()
+        + labs(x="Time (mins)", y="4kB Pages", title=title)
+    )
     return plt0

--- a/python/kernmlops/analysis/collector.py
+++ b/python/kernmlops/analysis/collector.py
@@ -5,23 +5,29 @@ from typing import cast
 import pexpect
 
 """ Collector class has helper methods to interact with kermit"""
+
+
 class Collector:
-    def __init__(self, config: Path, verbose: bool=True):
+    def __init__(self, config: Path, verbose: bool = True):
         self.env = os.environ.copy()
         self.env["INTERACTIVE"] = "it"
-        self.env["CONTAINER_CMD"] = f"bash -lc 'KERNMLOPS_CONFIG_FILE={config} make collect-data'"
-        self.collect_process : pexpect.spawn | None = None
+        self.env["CONTAINER_CMD"] = (
+            f"bash -lc 'KERNMLOPS_CONFIG_FILE={config} make collect-data'"
+        )
+        self.collect_process: pexpect.spawn | None = None
         self.config: Path = config
         self.verbose = verbose
 
     def start_collection(self, logfile=None) -> None:
         env = cast(os._Environ[str], {**os.environ, **self.env})
-        self.collect_process = pexpect.spawn("make docker", env=env, timeout=None, logfile=logfile)
+        self.collect_process = pexpect.spawn(
+            "make docker", env=env, timeout=None, logfile=logfile
+        )
         self.collect_process.expect_exact(["Started benchmark"])
 
     @staticmethod
     def _after_run_generate_file_data() -> dict[str, list[Path]]:
-        start_path : Path = Path("./data")
+        start_path: Path = Path("./data")
         list_of_collect_id_dirs = start_path.glob("*/*/*")
         latest_collect_id = max(list_of_collect_id_dirs, key=os.path.getctime)
         list_of_files = latest_collect_id.glob("*.*.parquet")

--- a/python/kernmlops/analysis/process_trace.py
+++ b/python/kernmlops/analysis/process_trace.py
@@ -1,13 +1,13 @@
 import polars as pl
 
 
-def filter_process_trace(process_trace_df: pl.DataFrame) -> pl.DataFrame :
+def filter_process_trace(process_trace_df: pl.DataFrame) -> pl.DataFrame:
     df = process_trace_df
     # Filter just the processes
     df = df.filter(pl.col("tgid") == pl.col("pid")).drop("collection_id")
 
     # Find the last name of each process
-    start_df = df.sort(pl.col("ts_ns"), descending = True)
+    start_df = df.sort(pl.col("ts_ns"), descending=True)
     helper_dict = {}
     for row in start_df.iter_rows():
         pid = row[0]
@@ -18,11 +18,21 @@ def filter_process_trace(process_trace_df: pl.DataFrame) -> pl.DataFrame :
 
     # Separate the start and end
     full_df = start_df.with_columns(
-            pl.col("pid").map_elements(lambda x : helper_dict.get(x, ""),
-                                       return_dtype=pl.String).alias("full_name"))
+        pl.col("pid")
+        .map_elements(lambda x: helper_dict.get(x, ""), return_dtype=pl.String)
+        .alias("full_name")
+    )
     full_df = full_df.drop(["tgid", "name"])
-    start_df = full_df.filter(pl.col("cap_type") == "start").rename({"ts_ns": "start_ns"}).drop("cap_type")
-    end_df = full_df.filter(pl.col("cap_type") == "end").rename({"ts_ns": "end_ns"}).drop(["cap_type", "full_name"])
+    start_df = (
+        full_df.filter(pl.col("cap_type") == "start")
+        .rename({"ts_ns": "start_ns"})
+        .drop("cap_type")
+    )
+    end_df = (
+        full_df.filter(pl.col("cap_type") == "end")
+        .rename({"ts_ns": "end_ns"})
+        .drop(["cap_type", "full_name"])
+    )
 
     # Join them to get the process table
     return start_df.join(end_df, "pid")

--- a/python/kernmlops/cli/__init__.py
+++ b/python/kernmlops/cli/__init__.py
@@ -60,7 +60,11 @@ def cli_collect_data(
     config_overrides = yaml.safe_load(config_file.read_text())
     config = KernmlopsConfig().merge(config_overrides)
     collector_config: GenericCollectorConfig = config.collector_config
-    name = benchmark_name if benchmark_name else str(config.benchmark_config.generic.benchmark)
+    name = (
+        benchmark_name
+        if benchmark_name
+        else str(config.benchmark_config.generic.benchmark)
+    )
     benchmark = benchmarks[name].from_config(config.benchmark_config)
     collect.run_collect(
         collector_config=collector_config,
@@ -89,7 +93,9 @@ def cli_collect_data(
 )
 def cli_collect_dump(input_dir: Path, benchmark_name: str | None):
     """Debug tool to dump collected data."""
-    kernmlops_dfs = data_import.read_parquet_dir(input_dir, benchmark_name=benchmark_name)
+    kernmlops_dfs = data_import.read_parquet_dir(
+        input_dir, benchmark_name=benchmark_name
+    )
     for name, kernmlops_df in kernmlops_dfs.items():
         print(f"{name}: {kernmlops_df}")
 
@@ -136,14 +142,22 @@ def cli_collect_dump(input_dir: Path, benchmark_name: str | None):
     type=bool,
     help="Use matplotlib to graph data",
 )
-def cli_collect_graph(input_dir: Path, output_dir: Path | None, collection_id: str, no_trends: bool, use_matplot: bool):
+def cli_collect_graph(
+    input_dir: Path,
+    output_dir: Path | None,
+    collection_id: str,
+    no_trends: bool,
+    use_matplot: bool,
+):
     """Debug tool to graph collected data."""
     collection_data = data_schema.CollectionData.from_data(
         data_dir=input_dir,
         collection_id=collection_id,
         table_types=data_schema.table_types,
     )
-    collection_data.dump(output_dir=output_dir, no_trends=no_trends, use_matplot=use_matplot)
+    collection_data.dump(
+        output_dir=output_dir, no_trends=no_trends, use_matplot=use_matplot
+    )
 
 
 @cli_collect.command("perf-list")

--- a/python/kernmlops/cli/collect.py
+++ b/python/kernmlops/cli/collect.py
@@ -27,14 +27,14 @@ def wait_for_END(run_event: Event, read):
         continue
     run_event.clear()
 
-def poll_instrumentation(
-  benchmark: Benchmark,
-  bpf_programs: list[data_collection.bpf.BPFProgram],
-  queue: Queue,
-  run_event: Event,
-  poll_rate: float = .5,
-) -> int:
 
+def poll_instrumentation(
+    benchmark: Benchmark,
+    bpf_programs: list[data_collection.bpf.BPFProgram],
+    queue: Queue,
+    run_event: Event,
+    poll_rate: float = 0.5,
+) -> int:
     return_code = None
     while return_code is None and run_event.is_set():
         try:
@@ -61,56 +61,96 @@ def poll_instrumentation(
     queue.put(return_code)
     return return_code
 
-def signal_handler_factory(event: Event):
-    return lambda x,y: event.clear()
 
-def output_collections_to_file(collection_id: str, collection_tables : list[data_schema.CollectionTable], bpf_programs: list[BPFProgram], name: str,
-                               benchmark_name: str, verbose: bool, output_dir: Path, ids: tuple[int,int] | None = None):
+def signal_handler_factory(event: Event):
+    return lambda x, y: event.clear()
+
+
+def output_collections_to_file(
+    collection_id: str,
+    collection_tables: list[data_schema.CollectionTable],
+    bpf_programs: list[BPFProgram],
+    name: str,
+    benchmark_name: str,
+    verbose: bool,
+    output_dir: Path,
+    ids: tuple[int, int] | None = None,
+):
     for bpf_program in bpf_programs:
         collection_tables.extend(bpf_program.pop_data())
     for collection_table in collection_tables:
         with pl.Config(tbl_cols=-1):
             if verbose:
                 print(f"{collection_table.name()}: {collection_table.table}")
-        full_path = Path(output_dir/benchmark_name/collection_id/f"{collection_table.name()}.{name}.parquet")
+        full_path = Path(
+            output_dir
+            / benchmark_name
+            / collection_id
+            / f"{collection_table.name()}.{name}.parquet"
+        )
         collection_table.table.write_parquet(full_path)
         if ids is not None:
             os.chown(full_path, ids[0], ids[1])
     return collection_tables
 
-def output_data_thread(collection_id: str, bpf_programs: list[BPFProgram], benchmark_name: str, run_event: Event,
-                       verbose: bool, output_dir: Path, lock: Lock, ended: bool, output_interval: int | float, user_id: int, group_id: int):
-    num : int = 0
+
+def output_data_thread(
+    collection_id: str,
+    bpf_programs: list[BPFProgram],
+    benchmark_name: str,
+    run_event: Event,
+    verbose: bool,
+    output_dir: Path,
+    lock: Lock,
+    ended: bool,
+    output_interval: int | float,
+    user_id: int,
+    group_id: int,
+):
+    num: int = 0
     sleep(output_interval)
     while run_event.is_set():
         lock.acquire()
         try:
-            if(ended):
+            if ended:
                 lock.release()
                 return
-            output_collections_to_file(collection_id, [], bpf_programs, str(num), benchmark_name, verbose, output_dir, (user_id, group_id))
+            output_collections_to_file(
+                collection_id,
+                [],
+                bpf_programs,
+                str(num),
+                benchmark_name,
+                verbose,
+                output_dir,
+                (user_id, group_id),
+            )
         except Exception as e:
             print(e)
         lock.release()
         num += 1
         sleep(output_interval)
 
-def run_collect(
-    *,
-    collector_config: ConfigBase,
-    benchmark: Benchmark,
-    verbose: bool
-):
+
+def run_collect(*, collector_config: ConfigBase, benchmark: Benchmark, verbose: bool):
     if not benchmark.is_configured():
-        raise BenchmarkNotConfiguredError(f"benchmark {benchmark.name()} is not configured")
+        raise BenchmarkNotConfiguredError(
+            f"benchmark {benchmark.name()} is not configured"
+        )
     benchmark.setup()
 
-    generic_config = cast(data_collection.GenericCollectorConfig, getattr(collector_config, "generic"))
+    generic_config = cast(
+        data_collection.GenericCollectorConfig, getattr(collector_config, "generic")
+    )
     bpf_programs = generic_config.get_hooks()
     system_info = data_collection.machine_info().to_polars()
     system_info = system_info.unnest(system_info.columns)
     collection_id = system_info["collection_id"][0]
-    output_dir = generic_config.get_output_dir() / "curated" if bpf_programs else generic_config.get_output_dir() / "baseline"
+    output_dir = (
+        generic_config.get_output_dir() / "curated"
+        if bpf_programs
+        else generic_config.get_output_dir() / "baseline"
+    )
     queue = Queue(maxsize=1)
     run_event = Event()
     run_event.set()
@@ -128,30 +168,50 @@ def run_collect(
     signal.signal(signal.SIGUSR1, signal_handler_factory(run_event))
 
     # Create stdin killer daemon
-    read_thread = Thread(target = wait_for_END, args = (run_event, sys.stdin))
+    read_thread = Thread(target=wait_for_END, args=(run_event, sys.stdin))
     read_thread.daemon = True
     read_thread.start()
 
     # Create polling thread
-    poll_thread = Thread(target = poll_instrumentation, args = (benchmark, bpf_programs, queue, run_event, generic_config.poll_rate))
+    poll_thread = Thread(
+        target=poll_instrumentation,
+        args=(benchmark, bpf_programs, queue, run_event, generic_config.poll_rate),
+    )
     poll_thread.start()
 
     # Create output thread
-    output_interval_parse : int | float | None = timeparse(generic_config.output_interval)
+    output_interval_parse: int | float | None = timeparse(
+        generic_config.output_interval
+    )
     output_interval = 60
     if output_interval_parse is not None:
         output_interval = output_interval_parse
     ended = False
     output_lock = Lock()
     (user_id, group_id) = get_user_group_ids()
-    Path(output_dir/benchmark.name()/collection_id).mkdir(parents=True, exist_ok=True)
+    Path(output_dir / benchmark.name() / collection_id).mkdir(
+        parents=True, exist_ok=True
+    )
     os.chown(generic_config.get_output_dir(), user_id, group_id)
     os.chown(output_dir, user_id, group_id)
-    os.chown(Path(output_dir/benchmark.name()), user_id, group_id)
-    os.chown(Path(output_dir/benchmark.name()/collection_id), user_id, group_id)
-    output_thread = Thread(target = output_data_thread, args = (collection_id, bpf_programs, benchmark.name(),
-                                                                run_event, generic_config.output_dfs, output_dir,
-                                                                output_lock, ended, output_interval, user_id, group_id))
+    os.chown(Path(output_dir / benchmark.name()), user_id, group_id)
+    os.chown(Path(output_dir / benchmark.name() / collection_id), user_id, group_id)
+    output_thread = Thread(
+        target=output_data_thread,
+        args=(
+            collection_id,
+            bpf_programs,
+            benchmark.name(),
+            run_event,
+            generic_config.output_dfs,
+            output_dir,
+            output_lock,
+            ended,
+            output_interval,
+            user_id,
+            group_id,
+        ),
+    )
     output_thread.daemon = True
     output_thread.start()
 
@@ -173,20 +233,31 @@ def run_collect(
 
     collection_tables: list[data_schema.CollectionTable] = [
         data_schema.SystemInfoTable.from_df(
-            system_info.with_columns([
-                pl.lit(collection_time_sec).alias("collection_time_sec"),
-                pl.lit(os.getpid()).alias("collection_pid"),
-                pl.lit(benchmark.name()).alias("benchmark_name"),
-                pl.lit([hook.name() for hook in bpf_programs]).cast(pl.List(pl.String())).alias("hooks"),
-            ])
+            system_info.with_columns(
+                [
+                    pl.lit(collection_time_sec).alias("collection_time_sec"),
+                    pl.lit(os.getpid()).alias("collection_pid"),
+                    pl.lit(benchmark.name()).alias("benchmark_name"),
+                    pl.lit([hook.name() for hook in bpf_programs])
+                    .cast(pl.List(pl.String()))
+                    .alias("hooks"),
+                ]
+            )
         )
     ]
 
     output_lock.acquire()
     ended = True
-    collection_tables = output_collections_to_file(collection_id, collection_tables, bpf_programs, "end",
-                                                   benchmark.name(), generic_config.output_dfs, output_dir,
-                                                   (user_id, group_id))
+    collection_tables = output_collections_to_file(
+        collection_id,
+        collection_tables,
+        bpf_programs,
+        "end",
+        benchmark.name(),
+        generic_config.output_dfs,
+        output_dir,
+        (user_id, group_id),
+    )
     output_lock.release()
     collection_data = data_schema.CollectionData.from_tables(collection_tables)
 

--- a/python/kernmlops/cli/config.py
+++ b/python/kernmlops/cli/config.py
@@ -17,12 +17,12 @@ KernmlopsConfig = make_dataclass(
             "collector_config",
             CollectorConfig,
             field(default=CollectorConfig()),
-        )
+        ),
     ],
     frozen=True,
 )
 
 
 __all__ = [
-  "KernmlopsConfig",
+    "KernmlopsConfig",
 ]

--- a/python/kernmlops/data_collection/bpf_instrumentation/__init__.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/__init__.py
@@ -42,8 +42,10 @@ all_hooks: Final[Mapping[str, type[BPFProgram]]] = {
     ZswapRuntimeBPFHook.name(): ZswapRuntimeBPFHook,
 }
 
+
 def hook_names() -> list[str]:
     return list(all_hooks.keys())
+
 
 __all__ = [
     "all_hooks",

--- a/python/kernmlops/data_collection/bpf_instrumentation/blk_io_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/blk_io_hook.py
@@ -11,125 +11,136 @@ from data_schema.block_io import BlockIOLatencyTable, BlockIOQueueTable, BlockIO
 
 @dataclass(frozen=True)
 class BlockIOQueueData:
-  cpu: int
-  device: int
-  sector: int
-  segments: int
-  block_io_bytes: int
-  block_io_start_uptime_us: int
-  block_io_flags: int
-  queue_length_segment_ios: int
-  queue_length_4k_ios: int
+    cpu: int
+    device: int
+    sector: int
+    segments: int
+    block_io_bytes: int
+    block_io_start_uptime_us: int
+    block_io_flags: int
+    queue_length_segment_ios: int
+    queue_length_4k_ios: int
+
 
 @dataclass(frozen=True)
 class BlockIOLatencyData:
-  cpu: int
-  device: int
-  sector: int
-  segments: int
-  block_io_bytes: int
-  block_io_end_uptime_us: int
-  block_latency_us: int
-  block_io_latency_us: int
-  block_io_flags: int
+    cpu: int
+    device: int
+    sector: int
+    segments: int
+    block_io_bytes: int
+    block_io_end_uptime_us: int
+    block_latency_us: int
+    block_io_latency_us: int
+    block_io_flags: int
+
 
 class BlockIOBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "block_io"
 
-  @classmethod
-  def name(cls) -> str:
-    return "block_io"
+    def __init__(self):
+        bpf_text = open(Path(__file__).parent / "bpf/blk_io.bpf.c", "r").read()
 
-  def __init__(self):
-    bpf_text = open(Path(__file__).parent / "bpf/blk_io.bpf.c", "r").read()
+        # code substitutions
+        if BPF.kernel_struct_has_field(b"request", b"rq_disk") == 1:
+            bpf_text = bpf_text.replace("__RQ_DISK__", "rq_disk")
+        else:
+            bpf_text = bpf_text.replace("__RQ_DISK__", "q->disk")
+        self.bpf_text = bpf_text
+        self.block_io_queue_data = list[BlockIOQueueData]()
+        self.block_io_latency_data = list[BlockIOLatencyData]()
 
-    # code substitutions
-    if BPF.kernel_struct_has_field(b'request', b'rq_disk') == 1:
-        bpf_text = bpf_text.replace('__RQ_DISK__', 'rq_disk')
-    else:
-        bpf_text = bpf_text.replace('__RQ_DISK__', 'q->disk')
-    self.bpf_text = bpf_text
-    self.block_io_queue_data = list[BlockIOQueueData]()
-    self.block_io_latency_data = list[BlockIOLatencyData]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        self.bpf["block_io_starts"].open_perf_buffer(
+            self._queue_event_handler, page_cnt=64
+        )
+        self.bpf["block_io_ends"].open_perf_buffer(
+            self._latency_event_handler, page_cnt=64
+        )
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    self.bpf["block_io_starts"].open_perf_buffer(self._queue_event_handler, page_cnt=64)
-    self.bpf["block_io_ends"].open_perf_buffer(self._latency_event_handler, page_cnt=64)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
+    def data(self) -> list[CollectionTable]:
+        return list[CollectionTable](
+            [
+                BlockIOTable.from_tables(
+                    latency_table=cast(
+                        BlockIOLatencyTable,
+                        BlockIOLatencyTable.from_df_id(
+                            pl.DataFrame(self.block_io_latency_data).rename(
+                                {
+                                    "block_io_end_uptime_us": UPTIME_TIMESTAMP,
+                                }
+                            ),
+                            collection_id=self.collection_id,
+                        ),
+                    ),
+                    queue_table=cast(
+                        BlockIOQueueTable,
+                        BlockIOQueueTable.from_df_id(
+                            pl.DataFrame(self.block_io_queue_data).rename(
+                                {
+                                    "block_io_start_uptime_us": UPTIME_TIMESTAMP,
+                                }
+                            ),
+                            collection_id=self.collection_id,
+                        ),
+                    ),
+                ),
+            ]
+        )
 
-  def data(self) -> list[CollectionTable]:
-    return list[CollectionTable]([
-      BlockIOTable.from_tables(
-        latency_table=cast(
-          BlockIOLatencyTable,
-          BlockIOLatencyTable.from_df_id(
-            pl.DataFrame(self.block_io_latency_data).rename({
-              "block_io_end_uptime_us": UPTIME_TIMESTAMP,
-            }),
-            collection_id=self.collection_id,
-          ),
-        ),
-        queue_table=cast(
-          BlockIOQueueTable,
-          BlockIOQueueTable.from_df_id(
-            pl.DataFrame(self.block_io_queue_data).rename({
-              "block_io_start_uptime_us": UPTIME_TIMESTAMP,
-            }),
-            collection_id=self.collection_id,
-          ),
-        ),
-      ),
-    ])
+    def clear(self):
+        self.block_io_queue_data.clear()
+        self.block_io_latency_data.clear()
 
-  def clear(self):
-    self.block_io_queue_data.clear()
-    self.block_io_latency_data.clear()
+    def pop_data(self) -> list[CollectionTable]:
+        block_io_tables = self.data()
+        self.clear()
+        return block_io_tables
 
-  def pop_data(self) -> list[CollectionTable]:
-    block_io_tables = self.data()
-    self.clear()
-    return block_io_tables
+    def _queue_event_handler(self, cpu, block_io_start_perf_event, size):
+        event = self.bpf["block_io_starts"].event(block_io_start_perf_event)
+        sector = event.sector
+        if sector == 18446744073709551615:  # this is -1 in a u64
+            sector = -1
+        self.block_io_queue_data.append(
+            BlockIOQueueData(
+                cpu=cpu,
+                device=event.device,
+                sector=sector,
+                segments=event.segments,
+                block_io_bytes=event.block_io_bytes,
+                block_io_start_uptime_us=event.block_io_start_uptime_us,
+                block_io_flags=event.block_io_flags,
+                queue_length_segment_ios=event.queue_length_segments,
+                queue_length_4k_ios=event.queue_length_4ks,
+            )
+        )
 
-  def _queue_event_handler(self, cpu, block_io_start_perf_event, size):
-    event = self.bpf["block_io_starts"].event(block_io_start_perf_event)
-    sector = event.sector
-    if sector == 18446744073709551615: # this is -1 in a u64
-      sector = -1
-    self.block_io_queue_data.append(
-      BlockIOQueueData(
-        cpu=cpu,
-        device=event.device,
-        sector=sector,
-        segments=event.segments,
-        block_io_bytes=event.block_io_bytes,
-        block_io_start_uptime_us=event.block_io_start_uptime_us,
-        block_io_flags=event.block_io_flags,
-        queue_length_segment_ios=event.queue_length_segments,
-        queue_length_4k_ios=event.queue_length_4ks,
-      )
-    )
-
-  def _latency_event_handler(self, cpu, block_io_end_perf_event, size):
-    event = self.bpf["block_io_ends"].event(block_io_end_perf_event)
-    sector = event.sector
-    if sector == 18446744073709551615: # this is -1 in a u64
-      sector = -1
-    self.block_io_latency_data.append(
-      BlockIOLatencyData(
-        cpu=cpu,
-        device=event.device,
-        sector=sector,
-        segments=event.segments,
-        block_io_bytes=event.block_io_bytes,
-        block_io_end_uptime_us=event.block_io_end_uptime_us,
-        block_latency_us=event.block_latency_us,
-        block_io_latency_us=event.block_io_latency_us,
-        block_io_flags=event.block_io_flags,
-      )
-    )
+    def _latency_event_handler(self, cpu, block_io_end_perf_event, size):
+        event = self.bpf["block_io_ends"].event(block_io_end_perf_event)
+        sector = event.sector
+        if sector == 18446744073709551615:  # this is -1 in a u64
+            sector = -1
+        self.block_io_latency_data.append(
+            BlockIOLatencyData(
+                cpu=cpu,
+                device=event.device,
+                sector=sector,
+                segments=event.segments,
+                block_io_bytes=event.block_io_bytes,
+                block_io_end_uptime_us=event.block_io_end_uptime_us,
+                block_latency_us=event.block_latency_us,
+                block_io_latency_us=event.block_io_latency_us,
+                block_io_flags=event.block_io_flags,
+            )
+        )

--- a/python/kernmlops/data_collection/bpf_instrumentation/bpf_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/bpf_hook.py
@@ -1,6 +1,5 @@
 """Abstract definition of a BPF program."""
 
-
 from data_schema import CollectionTable
 from typing_extensions import Final, Protocol
 
@@ -8,30 +7,30 @@ POLL_TIMEOUT_MS: Final[int] = 5
 
 
 class BPFProgram(Protocol):
-  """Loadable BPF program that returns performance data."""
+    """Loadable BPF program that returns performance data."""
 
-  @classmethod
-  def name(cls) -> str: ...
+    @classmethod
+    def name(cls) -> str: ...
 
-  def load(self, collection_id: str) -> None: ...
+    def load(self, collection_id: str) -> None: ...
 
-  def poll(self) -> None: ...
+    def poll(self) -> None: ...
 
-  def close(self) -> None: ...
+    def close(self) -> None: ...
 
-  def data(self) -> list[CollectionTable]: ...
+    def data(self) -> list[CollectionTable]: ...
 
-  # def last_k_ms(self, ms: int) -> list[CollectionTable]: ...
+    # def last_k_ms(self, ms: int) -> list[CollectionTable]: ...
 
-  # def last_k_data(self, k: int) -> list[CollectionTable]:
-  #   return [
-  #     table.limit(k)
-  #     for table in self.data()
-  #   ]
+    # def last_k_data(self, k: int) -> list[CollectionTable]:
+    #   return [
+    #     table.limit(k)
+    #     for table in self.data()
+    #   ]
 
-  # def last_data(self) -> list[CollectionTable]:
-  #   return self.last_data(1)
+    # def last_data(self) -> list[CollectionTable]:
+    #   return self.last_data(1)
 
-  def clear(self): ...
+    def clear(self): ...
 
-  def pop_data(self) -> list[CollectionTable]: ...
+    def pop_data(self) -> list[CollectionTable]: ...

--- a/python/kernmlops/data_collection/bpf_instrumentation/collapse_huge_page.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/collapse_huge_page.py
@@ -7,158 +7,180 @@ from bcc import BPF
 from data_collection.bpf_instrumentation.bpf_hook import POLL_TIMEOUT_MS, BPFProgram
 from data_schema import CollectionTable
 from data_schema.generic_table import (
-  CollapseHugePageDataTableRaw,
-  TraceMMCollapseHugePageDataTable,
-  TraceMMKhugepagedScanPMDDataTable,
+    CollapseHugePageDataTableRaw,
+    TraceMMCollapseHugePageDataTable,
+    TraceMMKhugepagedScanPMDDataTable,
 )
 from data_schema.huge_pages import (
-  CollapseHugePageDataTable,
+    CollapseHugePageDataTable,
 )
 
 
 @dataclass(frozen=True)
 class TraceMMKhugepagedScanPMDRuntimeData:
-  pid: int
-  tgid: int
-  start_ts_ns: int
-  end_ts_ns: int
-  mm: str
-  page: str
-  writeable: int
-  referenced: int
-  none_or_zero: int
-  status: int
-  unmapped: bool
+    pid: int
+    tgid: int
+    start_ts_ns: int
+    end_ts_ns: int
+    mm: str
+    page: str
+    writeable: int
+    referenced: int
+    none_or_zero: int
+    status: int
+    unmapped: bool
+
 
 @dataclass(frozen=True)
 class CollapseHugePageRuntimeData:
-  pid: int
-  tgid: int
-  start_ts_ns: int
-  end_ts_ns: int
-  mm: str
-  referenced: int
-  address: str
-  unmapped: int
-  referenced: int
-  cc: str
+    pid: int
+    tgid: int
+    start_ts_ns: int
+    end_ts_ns: int
+    mm: str
+    referenced: int
+    address: str
+    unmapped: int
+    referenced: int
+    cc: str
+
 
 @dataclass(frozen=True)
 class TraceMMCollapseHugePageRuntimeData:
-  pid: int
-  tgid: int
-  start_ts_ns: int
-  end_ts_ns: int
-  mm: str
-  isolated: bool
-  status: int
+    pid: int
+    tgid: int
+    start_ts_ns: int
+    end_ts_ns: int
+    mm: str
+    isolated: bool
+    status: int
+
 
 class CollapseHugePageBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "collapse_huge_pages"
 
-  @classmethod
-  def name(cls) -> str:
-    return "collapse_huge_pages"
+    def __init__(self):
+        self.is_support_raw_tp = True  #  BPF.support_raw_tracepoint()
+        self.bpf_text = open(
+            Path(__file__).parent / "bpf/collapse_huge_page.bpf.c", "r"
+        ).read()
+        self.collapse_huge_pages = list[CollapseHugePageRuntimeData]()
+        self.trace_mm_collapse_huge_pages = list[TraceMMCollapseHugePageRuntimeData]()
+        self.trace_mm_khugepaged_scan_pmds = list[TraceMMKhugepagedScanPMDRuntimeData]()
 
-  def __init__(self):
-    self.is_support_raw_tp = True #  BPF.support_raw_tracepoint()
-    self.bpf_text = open(Path(__file__).parent / "bpf/collapse_huge_page.bpf.c", "r").read()
-    self.collapse_huge_pages = list[CollapseHugePageRuntimeData]()
-    self.trace_mm_collapse_huge_pages = list[TraceMMCollapseHugePageRuntimeData]()
-    self.trace_mm_khugepaged_scan_pmds = list[TraceMMKhugepagedScanPMDRuntimeData]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        # self.bpf.attach_raw_tracepoint(tp=b"mm_collapse_huge_page", fn_name=b"mm_collapse_huge_page")
+        self.bpf.attach_kprobe(
+            event=b"collapse_huge_page", fn_name=b"kprobe_collapse_huge_page"
+        )
+        self.bpf["collapse_huge_pages"].open_perf_buffer(
+            self._collapse_huge_pages_eh, page_cnt=64
+        )
+        self.bpf["trace_mm_collapse_huge_pages"].open_perf_buffer(
+            self._trace_huge_pages_eh, page_cnt=64
+        )
+        self.bpf["trace_mm_khugepaged_scan_pmds"].open_perf_buffer(
+            self._trace_khugepaged_scan_eh, page_cnt=64
+        )
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    #self.bpf.attach_raw_tracepoint(tp=b"mm_collapse_huge_page", fn_name=b"mm_collapse_huge_page")
-    self.bpf.attach_kprobe(event=b"collapse_huge_page", fn_name=b"kprobe_collapse_huge_page")
-    self.bpf["collapse_huge_pages"].open_perf_buffer(self._collapse_huge_pages_eh, page_cnt=64)
-    self.bpf["trace_mm_collapse_huge_pages"].open_perf_buffer(self._trace_huge_pages_eh, page_cnt=64)
-    self.bpf["trace_mm_khugepaged_scan_pmds"].open_perf_buffer(self._trace_khugepaged_scan_eh, page_cnt=64)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
-
-  def data(self) -> list[CollectionTable]:
-    if len(self.collapse_huge_pages) == 0 or len(self.trace_mm_collapse_huge_pages) == 0 or len(self.trace_mm_khugepaged_scan_pmds) == 0:
-        return []
-    return [
+    def data(self) -> list[CollectionTable]:
+        if (
+            len(self.collapse_huge_pages) == 0
+            or len(self.trace_mm_collapse_huge_pages) == 0
+            or len(self.trace_mm_khugepaged_scan_pmds) == 0
+        ):
+            return []
+        return [
             CollapseHugePageDataTable.from_tables(
-              collapse_table=cast(
-                CollapseHugePageDataTableRaw,
-                CollapseHugePageDataTableRaw.from_df_id(
-                  pl.DataFrame(self.collapse_huge_pages),
-                  collection_id = self.collection_id,),
-              ),
-              trace_mm_table=cast(
-                TraceMMCollapseHugePageDataTable,
-                TraceMMCollapseHugePageDataTable.from_df_id(
-                  pl.DataFrame(self.trace_mm_collapse_huge_pages),
-                  collection_id = self.collection_id,),
-              ),
+                collapse_table=cast(
+                    CollapseHugePageDataTableRaw,
+                    CollapseHugePageDataTableRaw.from_df_id(
+                        pl.DataFrame(self.collapse_huge_pages),
+                        collection_id=self.collection_id,
+                    ),
+                ),
+                trace_mm_table=cast(
+                    TraceMMCollapseHugePageDataTable,
+                    TraceMMCollapseHugePageDataTable.from_df_id(
+                        pl.DataFrame(self.trace_mm_collapse_huge_pages),
+                        collection_id=self.collection_id,
+                    ),
+                ),
             ),
             TraceMMKhugepagedScanPMDDataTable.from_df_id(
                 pl.DataFrame(self.trace_mm_khugepaged_scan_pmds),
-                collection_id = self.collection_id,),
+                collection_id=self.collection_id,
+            ),
         ]
 
-  def clear(self):
-    self.collapse_huge_pages.clear()
-    self.trace_mm_collapse_huge_pages.clear()
-    self.trace_mm_khugepaged_scan_pmds.clear()
+    def clear(self):
+        self.collapse_huge_pages.clear()
+        self.trace_mm_collapse_huge_pages.clear()
+        self.trace_mm_khugepaged_scan_pmds.clear()
 
-  def pop_data(self) -> list[CollectionTable]:
-    quanta_tables = self.data()
-    self.clear()
-    return quanta_tables
+    def pop_data(self) -> list[CollectionTable]:
+        quanta_tables = self.data()
+        self.clear()
+        return quanta_tables
 
-  def _trace_khugepaged_scan_eh(self, cpu, trace_mm_khugepaged_scan_pmd_struct, size):
-      event = self.bpf["trace_mm_khugepaged_scan_pmds"].event(trace_mm_khugepaged_scan_pmd_struct)
-      self.trace_mm_khugepaged_scan_pmds.append(
-        TraceMMKhugepagedScanPMDRuntimeData(
-          pid=event.pid,
-          tgid=event.tgid,
-          start_ts_ns=event.start_ts_ns,
-          end_ts_ns=event.end_ts_ns,
-          mm=hex(event.mm),
-          page=hex(event.page),
-          writeable=event.writeable,
-          referenced=event.referenced,
-          none_or_zero=event.none_or_zero,
-          status=event.status,
-          unmapped=event.unmapped,
-          )
+    def _trace_khugepaged_scan_eh(self, cpu, trace_mm_khugepaged_scan_pmd_struct, size):
+        event = self.bpf["trace_mm_khugepaged_scan_pmds"].event(
+            trace_mm_khugepaged_scan_pmd_struct
+        )
+        self.trace_mm_khugepaged_scan_pmds.append(
+            TraceMMKhugepagedScanPMDRuntimeData(
+                pid=event.pid,
+                tgid=event.tgid,
+                start_ts_ns=event.start_ts_ns,
+                end_ts_ns=event.end_ts_ns,
+                mm=hex(event.mm),
+                page=hex(event.page),
+                writeable=event.writeable,
+                referenced=event.referenced,
+                none_or_zero=event.none_or_zero,
+                status=event.status,
+                unmapped=event.unmapped,
+            )
         )
 
+    def _trace_huge_pages_eh(self, cpu, trace_mm_collapse_huge_page_struct, size):
+        event = self.bpf["trace_mm_collapse_huge_pages"].event(
+            trace_mm_collapse_huge_page_struct
+        )
+        self.trace_mm_collapse_huge_pages.append(
+            TraceMMCollapseHugePageRuntimeData(
+                pid=event.pid,
+                tgid=event.tgid,
+                start_ts_ns=event.start_ts_ns,
+                end_ts_ns=event.end_ts_ns,
+                mm=hex(event.mm),
+                isolated=event.isolated,
+                status=event.status,
+            )
+        )
 
-  def _trace_huge_pages_eh(self, cpu, trace_mm_collapse_huge_page_struct, size):
-    event = self.bpf["trace_mm_collapse_huge_pages"].event(trace_mm_collapse_huge_page_struct)
-    self.trace_mm_collapse_huge_pages.append(
-      TraceMMCollapseHugePageRuntimeData(
-          pid=event.pid,
-          tgid=event.tgid,
-          start_ts_ns=event.start_ts_ns,
-          end_ts_ns=event.end_ts_ns,
-          mm=hex(event.mm),
-          isolated=event.isolated,
-          status=event.status,
-      )
-    )
-
-  def _collapse_huge_pages_eh(self, cpu, collapse_huge_page_struct, size):
-    event = self.bpf["collapse_huge_pages"].event(collapse_huge_page_struct)
-    self.collapse_huge_pages.append(
-      CollapseHugePageRuntimeData(
-          pid=event.pid,
-          tgid=event.tgid,
-          start_ts_ns=event.start_ts_ns,
-          end_ts_ns=event.end_ts_ns,
-          mm=hex(event.mm),
-          address=hex(event.address),
-          referenced=event.referenced,
-          unmapped=event.unmapped,
-          cc=hex(event.cc),
-      )
-    )
+    def _collapse_huge_pages_eh(self, cpu, collapse_huge_page_struct, size):
+        event = self.bpf["collapse_huge_pages"].event(collapse_huge_page_struct)
+        self.collapse_huge_pages.append(
+            CollapseHugePageRuntimeData(
+                pid=event.pid,
+                tgid=event.tgid,
+                start_ts_ns=event.start_ts_ns,
+                end_ts_ns=event.end_ts_ns,
+                mm=hex(event.mm),
+                address=hex(event.address),
+                referenced=event.referenced,
+                unmapped=event.unmapped,
+                cc=hex(event.cc),
+            )
+        )

--- a/python/kernmlops/data_collection/bpf_instrumentation/file_data_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/file_data_hook.py
@@ -9,85 +9,88 @@ from data_schema import CollectionTable, FileDataTable
 
 @dataclass(frozen=True)
 class FileOpenData:
-  cpu: int
-  pid: int
-  tgid: int
-  ts_uptime_us: int
-  file_inode: int
-  file_size_bytes: int
-  file_name: str
+    cpu: int
+    pid: int
+    tgid: int
+    ts_uptime_us: int
+    file_inode: int
+    file_size_bytes: int
+    file_name: str
 
 
 class FileDataBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "file_data"
 
-  @classmethod
-  def name(cls) -> str:
-    return "file_data"
+    def __init__(self):
+        bpf_text = open(Path(__file__).parent / "bpf/file_data.bpf.c", "r").read()
 
-  def __init__(self):
-    bpf_text = open(Path(__file__).parent / "bpf/file_data.bpf.c", "r").read()
+        # code substitutions
+        if BPF.kernel_struct_has_field(b"renamedata", b"new_mnt_idmap") == 1:
+            bpf_text = bpf_text.replace("TRACE_CREATE_1", "0")
+            bpf_text = bpf_text.replace("TRACE_CREATE_2", "0")
+            bpf_text = bpf_text.replace("TRACE_CREATE_3", "1")
+        elif BPF.kernel_struct_has_field(b"renamedata", b"old_mnt_userns") == 1:
+            bpf_text = bpf_text.replace("TRACE_CREATE_1", "0")
+            bpf_text = bpf_text.replace("TRACE_CREATE_2", "1")
+            bpf_text = bpf_text.replace("TRACE_CREATE_3", "0")
+        else:
+            bpf_text = bpf_text.replace("TRACE_CREATE_1", "1")
+            bpf_text = bpf_text.replace("TRACE_CREATE_2", "0")
+            bpf_text = bpf_text.replace("TRACE_CREATE_3", "0")
+        # pid from userspace point of view is thread group from kernel pov
+        # bpf_text = bpf_text.replace('FILTER', 'tgid != %s' % args.pid)
+        self.bpf_text = bpf_text.replace("FILTER", "0")
+        self.file_open_data = list[FileOpenData]()
 
-    # code substitutions
-    if BPF.kernel_struct_has_field(b'renamedata', b'new_mnt_idmap') == 1:
-        bpf_text = bpf_text.replace('TRACE_CREATE_1', '0')
-        bpf_text = bpf_text.replace('TRACE_CREATE_2', '0')
-        bpf_text = bpf_text.replace('TRACE_CREATE_3', '1')
-    elif BPF.kernel_struct_has_field(b'renamedata', b'old_mnt_userns') == 1:
-        bpf_text = bpf_text.replace('TRACE_CREATE_1', '0')
-        bpf_text = bpf_text.replace('TRACE_CREATE_2', '1')
-        bpf_text = bpf_text.replace('TRACE_CREATE_3', '0')
-    else:
-        bpf_text = bpf_text.replace('TRACE_CREATE_1', '1')
-        bpf_text = bpf_text.replace('TRACE_CREATE_2', '0')
-        bpf_text = bpf_text.replace('TRACE_CREATE_3', '0')
-    # pid from userspace point of view is thread group from kernel pov
-    # bpf_text = bpf_text.replace('FILTER', 'tgid != %s' % args.pid)
-    self.bpf_text = bpf_text.replace('FILTER', '0')
-    self.file_open_data = list[FileOpenData]()
-
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    self.bpf.attach_kprobe(event=b"vfs_create", fn_name=b"trace_create")
-    self.bpf.attach_kprobe(event=b"vfs_open", fn_name=b"trace_open")
-    if BPF.get_kprobe_functions(b"security_inode_create"):
-        self.bpf.attach_kprobe(event=b"security_inode_create", fn_name=b"trace_security_inode_create")
-    self.bpf["file_open_events"].open_perf_buffer(self._file_open_event_handler, page_cnt=64)
-
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
-
-  def close(self):
-    self.bpf.cleanup()
-
-  def data(self) -> list[CollectionTable]:
-    return [
-      FileDataTable.from_df_id(
-        pl.DataFrame(self.file_open_data),
-        collection_id=self.collection_id,
-      ),
-    ]
-
-  def clear(self):
-    self.file_open_data.clear()
-
-  def pop_data(self) -> list[CollectionTable]:
-    file_tables = self.data()
-    self.clear()
-    return file_tables
-
-  def _file_open_event_handler(self, cpu, file_open_perf_event, size):
-    event = self.bpf["file_open_events"].event(file_open_perf_event)
-    try:
-        data = FileOpenData(
-            cpu=cpu,
-            pid=event.pid,
-            tgid=event.tgid,
-            ts_uptime_us=event.ts_uptime_us,
-            file_inode=event.file_inode,
-            file_size_bytes=event.file_size_bytes,
-            file_name=event.file_name.decode('utf-8'),
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        self.bpf.attach_kprobe(event=b"vfs_create", fn_name=b"trace_create")
+        self.bpf.attach_kprobe(event=b"vfs_open", fn_name=b"trace_open")
+        if BPF.get_kprobe_functions(b"security_inode_create"):
+            self.bpf.attach_kprobe(
+                event=b"security_inode_create", fn_name=b"trace_security_inode_create"
+            )
+        self.bpf["file_open_events"].open_perf_buffer(
+            self._file_open_event_handler, page_cnt=64
         )
-        self.file_open_data.append(data)
-    except Exception as _:
-       pass
+
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+
+    def close(self):
+        self.bpf.cleanup()
+
+    def data(self) -> list[CollectionTable]:
+        return [
+            FileDataTable.from_df_id(
+                pl.DataFrame(self.file_open_data),
+                collection_id=self.collection_id,
+            ),
+        ]
+
+    def clear(self):
+        self.file_open_data.clear()
+
+    def pop_data(self) -> list[CollectionTable]:
+        file_tables = self.data()
+        self.clear()
+        return file_tables
+
+    def _file_open_event_handler(self, cpu, file_open_perf_event, size):
+        event = self.bpf["file_open_events"].event(file_open_perf_event)
+        try:
+            data = FileOpenData(
+                cpu=cpu,
+                pid=event.pid,
+                tgid=event.tgid,
+                ts_uptime_us=event.ts_uptime_us,
+                file_inode=event.file_inode,
+                file_size_bytes=event.file_size_bytes,
+                file_name=event.file_name.decode("utf-8"),
+            )
+            self.file_open_data.append(data)
+        except Exception as _:
+            pass

--- a/python/kernmlops/data_collection/bpf_instrumentation/fork_and_exit.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/fork_and_exit.py
@@ -10,86 +10,90 @@ from data_schema.generic_table import ProcessTraceDataTable
 
 @dataclass(frozen=True)
 class TraceProcessStat:
-  pid: int
-  tgid: int
-  ts_ns: int
-  name: str
-  cap_type: str
+    pid: int
+    tgid: int
+    ts_ns: int
+    name: str
+    cap_type: str
+
 
 class TraceProcessHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "process_trace"
 
-  @classmethod
-  def name(cls) -> str:
-    return "process_trace"
+    def __init__(self):
+        self.bpf_text = open(
+            Path(__file__).parent / "bpf/fork_and_exit.bpf.c", "r"
+        ).read()
+        self.trace_process = list[TraceProcessStat]()
 
-  def __init__(self):
-    self.bpf_text = open(Path(__file__).parent / "bpf/fork_and_exit.bpf.c", "r").read()
-    self.trace_process = list[TraceProcessStat]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        self.bpf.attach_kretprobe(
+            event=b"copy_process", fn_name=b"kretprobe_copy_process"
+        )
+        self.bpf.attach_kprobe(event=b"do_exit", fn_name=b"kprobe_do_exit")
+        self.bpf.attach_kretprobe(event=b"__set_task_comm", fn_name=b"kretprobe_exec")
+        self.bpf["copy_task_events"].open_perf_buffer(
+            self._create_task_eh, page_cnt=128
+        )
+        self.bpf["release_task_events"].open_perf_buffer(
+            self._release_task_eh, page_cnt=128
+        )
+        self.bpf["exec_events"].open_perf_buffer(self._exec_eh, page_cnt=128)
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    self.bpf.attach_kretprobe(event=b"copy_process", fn_name=b"kretprobe_copy_process")
-    self.bpf.attach_kprobe(event=b"do_exit", fn_name=b"kprobe_do_exit")
-    self.bpf.attach_kretprobe(event=b"__set_task_comm", fn_name=b"kretprobe_exec")
-    self.bpf["copy_task_events"].open_perf_buffer(self._create_task_eh, page_cnt=128)
-    self.bpf["release_task_events"].open_perf_buffer(self._release_task_eh, page_cnt=128)
-    self.bpf["exec_events"].open_perf_buffer(self._exec_eh, page_cnt=128)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
-
-  def data(self) -> list[CollectionTable]:
-    return [
+    def data(self) -> list[CollectionTable]:
+        return [
             ProcessTraceDataTable.from_df_id(
                 pl.DataFrame(self.trace_process),
                 collection_id=self.collection_id,
             ),
         ]
 
-  def clear(self):
-    self.trace_process.clear()
+    def clear(self):
+        self.trace_process.clear()
 
-  def pop_data(self) -> list[CollectionTable]:
-    tables = self.data()
-    self.clear()
-    return tables
+    def pop_data(self) -> list[CollectionTable]:
+        tables = self.data()
+        self.clear()
+        return tables
 
-  def _create_task_eh(self, cpu, start_data, size):
-      event = self.bpf["copy_task_events"].event(start_data)
-      self.trace_process.append(
-        TraceProcessStat(
-          pid=event.pid,
-          tgid=event.tgid,
-          ts_ns=event.ts,
-          name=event.buff.decode("ascii"),
-          cap_type="start"
+    def _create_task_eh(self, cpu, start_data, size):
+        event = self.bpf["copy_task_events"].event(start_data)
+        self.trace_process.append(
+            TraceProcessStat(
+                pid=event.pid,
+                tgid=event.tgid,
+                ts_ns=event.ts,
+                name=event.buff.decode("ascii"),
+                cap_type="start",
+            )
         )
-      )
 
-  def _release_task_eh(self, cpu, start_data, size):
-      event = self.bpf["release_task_events"].event(start_data)
-      self.trace_process.append(
-        TraceProcessStat(
-          pid=event.pid,
-          tgid=event.tgid,
-          ts_ns=event.ts,
-          name="",
-          cap_type="end"
+    def _release_task_eh(self, cpu, start_data, size):
+        event = self.bpf["release_task_events"].event(start_data)
+        self.trace_process.append(
+            TraceProcessStat(
+                pid=event.pid, tgid=event.tgid, ts_ns=event.ts, name="", cap_type="end"
+            )
         )
-      )
 
-  def _exec_eh(self, cpu, start_data, size):
-      event = self.bpf["exec_events"].event(start_data)
-      self.trace_process.append(
-        TraceProcessStat(
-          pid=event.pid,
-          tgid=event.tgid,
-          ts_ns=event.ts,
-          name=event.buff.decode("ascii"),
-          cap_type="exec"
+    def _exec_eh(self, cpu, start_data, size):
+        event = self.bpf["exec_events"].event(start_data)
+        self.trace_process.append(
+            TraceProcessStat(
+                pid=event.pid,
+                tgid=event.tgid,
+                ts_ns=event.ts,
+                name=event.buff.decode("ascii"),
+                cap_type="exec",
+            )
         )
-      )

--- a/python/kernmlops/data_collection/bpf_instrumentation/madvise.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/madvise.py
@@ -9,96 +9,101 @@ from data_schema.generic_table import MadviseDataTable
 
 ADVICE_ASSIGN_DICT = {
     -1: "MUNMAP",
-    0:"MADV_NORMAL",
-    1:"MADV_RANDOM",
-    2:"MADV_SEQUENTIAL",
-    3:"MADV_WILLNEED",
-    4:"MADV_DONTNEED",
-    8:"MADV_FREE",
-    9:"MADV_REMOVE",
-    10:"MADV_DONTFORK",
-    11:"MADV_DOFORK",
-    100:"MADV_HWPOISON",
-    101:"MADV_SOFT_OFFLINE",
-    12:"MADV_MERGEABLE",
-    13:"MADV_UNMERGEABLE",
-    14:"MADV_HUGEPAGE",
-    15:"MADV_NOHUGEPAGE",
-    16:"MADV_DONTDUMP",
-    17:"MADV_DODUMP",
-    18:"MADV_WIPEONFORK",
-    19:"MADV_KEEPONFORK",
-    20:"MADV_COLD",
-    21:"MADV_PAGEOUT",
-    22:"MADV_POPULATE_READ",
-    23:"MADV_POPULATE_WRITE",
-    24:"MADV_DONTNEED_LOCKED",
-    25:"MADV_COLLAPSE",
+    0: "MADV_NORMAL",
+    1: "MADV_RANDOM",
+    2: "MADV_SEQUENTIAL",
+    3: "MADV_WILLNEED",
+    4: "MADV_DONTNEED",
+    8: "MADV_FREE",
+    9: "MADV_REMOVE",
+    10: "MADV_DONTFORK",
+    11: "MADV_DOFORK",
+    100: "MADV_HWPOISON",
+    101: "MADV_SOFT_OFFLINE",
+    12: "MADV_MERGEABLE",
+    13: "MADV_UNMERGEABLE",
+    14: "MADV_HUGEPAGE",
+    15: "MADV_NOHUGEPAGE",
+    16: "MADV_DONTDUMP",
+    17: "MADV_DODUMP",
+    18: "MADV_WIPEONFORK",
+    19: "MADV_KEEPONFORK",
+    20: "MADV_COLD",
+    21: "MADV_PAGEOUT",
+    22: "MADV_POPULATE_READ",
+    23: "MADV_POPULATE_WRITE",
+    24: "MADV_DONTNEED_LOCKED",
+    25: "MADV_COLLAPSE",
 }
+
 
 @dataclass(frozen=True)
 class MadviseStat:
-  tgid: pl.UInt32
-  ts_ns: pl.UInt64
-  address: pl.UInt64
-  length: pl.UInt64
-  advice: str
+    tgid: pl.UInt32
+    ts_ns: pl.UInt64
+    address: pl.UInt64
+    length: pl.UInt64
+    advice: str
+
 
 class MadviseBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "madvise"
 
-  @classmethod
-  def name(cls) -> str:
-    return "madvise"
+    def __init__(self):
+        self.is_support_raw_tp = True  #  BPF.support_raw_tracepoint()
+        self.bpf_text = open(Path(__file__).parent / "bpf/madvise.bpf.c", "r").read()
+        self.madvise_stat = list[MadviseStat]()
 
-  def __init__(self):
-    self.is_support_raw_tp = True #  BPF.support_raw_tracepoint()
-    self.bpf_text = open(Path(__file__).parent / "bpf/madvise.bpf.c", "r").read()
-    self.madvise_stat = list[MadviseStat]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        self.bpf.attach_kprobe(event=b"do_madvise", fn_name=b"kprobe__do_madvise")
+        self.bpf.attach_kretprobe(event=b"do_madvise", fn_name=b"kretprobe__do_madvise")
+        self.bpf.attach_kprobe(
+            event=b"do_vmi_align_munmap", fn_name=b"kprobe__do_vmi_align_munmap"
+        )
+        self.bpf.attach_kretprobe(
+            event=b"do_vmi_align_munmap", fn_name=b"kretprobe__do_vmi_align_munmap"
+        )
+        self.bpf["madvise_output"].open_perf_buffer(self._madvise_eh, page_cnt=64)
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    self.bpf.attach_kprobe(event=b"do_madvise",
-                           fn_name=b"kprobe__do_madvise")
-    self.bpf.attach_kretprobe(event=b"do_madvise",
-                              fn_name=b"kretprobe__do_madvise")
-    self.bpf.attach_kprobe(event=b"do_vmi_align_munmap",
-                           fn_name=b"kprobe__do_vmi_align_munmap")
-    self.bpf.attach_kretprobe(event=b"do_vmi_align_munmap",
-                              fn_name=b"kretprobe__do_vmi_align_munmap")
-    self.bpf["madvise_output"].open_perf_buffer(self._madvise_eh, page_cnt=64)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
-
-  def data(self) -> list[CollectionTable]:
-    return [
+    def data(self) -> list[CollectionTable]:
+        return [
             MadviseDataTable.from_df_id(
                 pl.DataFrame(self.madvise_stat),
                 collection_id=self.collection_id,
             ),
         ]
 
-  def clear(self):
-    self.madvise_stat.clear()
+    def clear(self):
+        self.madvise_stat.clear()
 
-  def pop_data(self) -> list[CollectionTable]:
-    tables = self.data()
-    self.clear()
-    return tables
+    def pop_data(self) -> list[CollectionTable]:
+        tables = self.data()
+        self.clear()
+        return tables
 
-  def _madvise_eh(self, cpu, madvise_struct, size):
-      event = self.bpf["madvise_output"].event(madvise_struct)
-      advice = ADVICE_ASSIGN_DICT[event.advice] if event.advice in ADVICE_ASSIGN_DICT.keys() else "UNKNOWN"
-      self.madvise_stat.append(
-        MadviseStat(
-          tgid=event.tgid,
-          ts_ns=event.ts_ns,
-          address=event.address,
-          length=event.length,
-          advice=advice,
+    def _madvise_eh(self, cpu, madvise_struct, size):
+        event = self.bpf["madvise_output"].event(madvise_struct)
+        advice = (
+            ADVICE_ASSIGN_DICT[event.advice]
+            if event.advice in ADVICE_ASSIGN_DICT.keys()
+            else "UNKNOWN"
         )
-      )
+        self.madvise_stat.append(
+            MadviseStat(
+                tgid=event.tgid,
+                ts_ns=event.ts_ns,
+                address=event.address,
+                length=event.length,
+                advice=advice,
+            )
+        )

--- a/python/kernmlops/data_collection/bpf_instrumentation/memory_usage_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/memory_usage_hook.py
@@ -12,126 +12,116 @@ from data_schema.memory_usage import MemoryUsageTable
 # Documentation: https://access.redhat.com/solutions/406773
 @dataclass(frozen=True)
 class MemoryUsageData:
-  ts_uptime_us: int
+    ts_uptime_us: int
 
-  mem_total_bytes: int
-  mem_free_bytes: int
-  mem_available_bytes: int
-  buffers_bytes: int
-  cached_bytes: int
+    mem_total_bytes: int
+    mem_free_bytes: int
+    mem_available_bytes: int
+    buffers_bytes: int
+    cached_bytes: int
 
-  swap_total_bytes: int
-  swap_free_bytes: int
+    swap_total_bytes: int
+    swap_free_bytes: int
 
-  # data waiting to be written back to disk
-  dirty_bytes: int
-  writeback_bytes: int
+    # data waiting to be written back to disk
+    dirty_bytes: int
+    writeback_bytes: int
 
-  anon_pages_total_bytes: int
-  anon_hugepages_total_bytes: int
-  mapped_total_bytes: int
-  shmem_total_bytes: int
+    anon_pages_total_bytes: int
+    anon_hugepages_total_bytes: int
+    mapped_total_bytes: int
+    shmem_total_bytes: int
 
-  hugepages_total: int
-  hugepages_free: int
-  hugepages_reserved: int
-  hugepage_size_bytes: int
+    hugepages_total: int
+    hugepages_free: int
+    hugepages_reserved: int
+    hugepage_size_bytes: int
 
-  hardware_corrupted_bytes: int
+    hardware_corrupted_bytes: int
 
-  @classmethod
-  def from_procfs_map(cls, ts_uptime_us: int, procfs_map: Mapping[str, int]) -> "MemoryUsageData":
-    return MemoryUsageData(
-      ts_uptime_us=ts_uptime_us,
-
-      mem_total_bytes=procfs_map.get("MemTotal", 0) * 1024,
-      mem_free_bytes=procfs_map.get("MemFree", 0) * 1024,
-      mem_available_bytes=procfs_map.get("MemAvailable", 0) * 1024,
-      buffers_bytes=procfs_map.get("Buffers", 0) * 1024,
-      cached_bytes=procfs_map.get("Cached", 0) * 1024,
-
-      swap_total_bytes=procfs_map.get("SwapTotal", 0) * 1024,
-      swap_free_bytes=procfs_map.get("SwapFree", 0) * 1024,
-
-      dirty_bytes=procfs_map.get("Dirty", 0) * 1024,
-      writeback_bytes=procfs_map.get("Writeback", 0) * 1024,
-
-      anon_pages_total_bytes=procfs_map.get("AnonPages", 0) * 1024,
-      anon_hugepages_total_bytes=procfs_map.get("AnonHugePages", 0) * 1024,
-      mapped_total_bytes=procfs_map.get("Mapped", 0) * 1024,
-      shmem_total_bytes=procfs_map.get("Shmem", 0) * 1024,
-
-      hugepages_total=procfs_map.get("HugePages_Total", 0) * 1024,
-      hugepages_free=procfs_map.get("HugePages_Free", 0) * 1024,
-      hugepages_reserved=procfs_map.get("HugePages_Rsvd", 0) * 1024,
-      hugepage_size_bytes=procfs_map.get("Hugepagesize", 0) * 1024,
-
-      hardware_corrupted_bytes=procfs_map.get("HardwareCorrupted", 0) * 1024,
-    )
+    @classmethod
+    def from_procfs_map(
+        cls, ts_uptime_us: int, procfs_map: Mapping[str, int]
+    ) -> "MemoryUsageData":
+        return MemoryUsageData(
+            ts_uptime_us=ts_uptime_us,
+            mem_total_bytes=procfs_map.get("MemTotal", 0) * 1024,
+            mem_free_bytes=procfs_map.get("MemFree", 0) * 1024,
+            mem_available_bytes=procfs_map.get("MemAvailable", 0) * 1024,
+            buffers_bytes=procfs_map.get("Buffers", 0) * 1024,
+            cached_bytes=procfs_map.get("Cached", 0) * 1024,
+            swap_total_bytes=procfs_map.get("SwapTotal", 0) * 1024,
+            swap_free_bytes=procfs_map.get("SwapFree", 0) * 1024,
+            dirty_bytes=procfs_map.get("Dirty", 0) * 1024,
+            writeback_bytes=procfs_map.get("Writeback", 0) * 1024,
+            anon_pages_total_bytes=procfs_map.get("AnonPages", 0) * 1024,
+            anon_hugepages_total_bytes=procfs_map.get("AnonHugePages", 0) * 1024,
+            mapped_total_bytes=procfs_map.get("Mapped", 0) * 1024,
+            shmem_total_bytes=procfs_map.get("Shmem", 0) * 1024,
+            hugepages_total=procfs_map.get("HugePages_Total", 0) * 1024,
+            hugepages_free=procfs_map.get("HugePages_Free", 0) * 1024,
+            hugepages_reserved=procfs_map.get("HugePages_Rsvd", 0) * 1024,
+            hugepage_size_bytes=procfs_map.get("Hugepagesize", 0) * 1024,
+            hardware_corrupted_bytes=procfs_map.get("HardwareCorrupted", 0) * 1024,
+        )
 
 
 @dataclass(frozen=True)
 class MemoryUsageDataRaw:
-  ts_uptime_us: int
-  procfs_dump: str
+    ts_uptime_us: int
+    procfs_dump: str
 
-  def parse(self) -> MemoryUsageData:
-    procfs_lines = [
-      line.split(":", maxsplit=1)
-      for line in self.procfs_dump.splitlines()
-    ]
-    procfs_map = {
-      line[0].lstrip().rstrip(): int(line[1].removesuffix("kB").lstrip().rstrip())
-      for line in procfs_lines
-      if len(line) == 2
-    }
-    return MemoryUsageData.from_procfs_map(self.ts_uptime_us, procfs_map)
-
+    def parse(self) -> MemoryUsageData:
+        procfs_lines = [
+            line.split(":", maxsplit=1) for line in self.procfs_dump.splitlines()
+        ]
+        procfs_map = {
+            line[0].lstrip().rstrip(): int(line[1].removesuffix("kB").lstrip().rstrip())
+            for line in procfs_lines
+            if len(line) == 2
+        }
+        return MemoryUsageData.from_procfs_map(self.ts_uptime_us, procfs_map)
 
 
 class MemoryUsageHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "memory_usage"
 
-  @classmethod
-  def name(cls) -> str:
-    return "memory_usage"
+    @classmethod
+    def _procfs_file(cls) -> Path:
+        return Path("/proc/meminfo")
 
-  @classmethod
-  def _procfs_file(cls) -> Path:
-    return Path("/proc/meminfo")
+    def __init__(self):
+        pass
 
-  def __init__(self):
-    pass
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.memory_usage = list[MemoryUsageDataRaw]()
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.memory_usage = list[MemoryUsageDataRaw]()
+    def poll(self):
+        self.memory_usage.append(
+            MemoryUsageDataRaw(
+                ts_uptime_us=int(time.clock_gettime_ns(time.CLOCK_BOOTTIME) / 1000),
+                procfs_dump=self._procfs_file().open("r").read(),
+            )
+        )
 
-  def poll(self):
-    self.memory_usage.append(
-      MemoryUsageDataRaw(
-        ts_uptime_us=int(time.clock_gettime_ns(time.CLOCK_BOOTTIME) / 1000),
-        procfs_dump=self._procfs_file().open("r").read(),
-      )
-    )
+    def close(self):
+        pass
 
-  def close(self):
-    pass
+    def data(self) -> list[CollectionTable]:
+        return [
+            MemoryUsageTable.from_df_id(
+                pl.DataFrame([raw_data.parse() for raw_data in self.memory_usage]),
+                collection_id=self.collection_id,
+            )
+        ]
 
-  def data(self) -> list[CollectionTable]:
-    return [
-      MemoryUsageTable.from_df_id(
-        pl.DataFrame([
-          raw_data.parse()
-          for raw_data in self.memory_usage
-        ]),
-        collection_id=self.collection_id,
-      )
-    ]
+    def clear(self):
+        self.memory_usage.clear()
 
-  def clear(self):
-    self.memory_usage.clear()
-
-  def pop_data(self) -> list[CollectionTable]:
-    memory_table = self.data()
-    self.clear()
-    return memory_table
+    def pop_data(self) -> list[CollectionTable]:
+        memory_table = self.data()
+        self.clear()
+        return memory_table

--- a/python/kernmlops/data_collection/bpf_instrumentation/mm_rss_stat.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/mm_rss_stat.py
@@ -10,61 +10,66 @@ from data_schema.generic_table import TraceMMRSSStatDataTable
 
 @dataclass(frozen=True)
 class TraceRSSStat:
-  pid: int
-  tgid: int
-  ts_ns: int
-  member: str
-  count: int
+    pid: int
+    tgid: int
+    ts_ns: int
+    member: str
+    count: int
+
 
 MEMBER_ASSIGN_ARR = ["MM_FILEPAGES", "MM_ANONPAGES", "MM_SWAPENTS", "MM_SHMEMPAGES"]
 
+
 class TraceRSSStatBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "mm_rss_stat"
 
-  @classmethod
-  def name(cls) -> str:
-    return "mm_rss_stat"
+    def __init__(self):
+        self.is_support_raw_tp = True  #  BPF.support_raw_tracepoint()
+        self.bpf_text = open(
+            Path(__file__).parent / "bpf/mm_trace_rss_stat.bpf.c", "r"
+        ).read()
+        self.trace_rss_stat = list[TraceRSSStat]()
 
-  def __init__(self):
-    self.is_support_raw_tp = True #  BPF.support_raw_tracepoint()
-    self.bpf_text = open(Path(__file__).parent / "bpf/mm_trace_rss_stat.bpf.c", "r").read()
-    self.trace_rss_stat = list[TraceRSSStat]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        # self.bpf.attach_raw_tracepoint(tp=b"mm_trace_rss_stat", fn_name=b"mm_trace_rss_stat")
+        self.bpf["rss_stat_output"].open_perf_buffer(
+            self._mm_trace_rss_stat_eh, page_cnt=256
+        )
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    #self.bpf.attach_raw_tracepoint(tp=b"mm_trace_rss_stat", fn_name=b"mm_trace_rss_stat")
-    self.bpf["rss_stat_output"].open_perf_buffer(self._mm_trace_rss_stat_eh, page_cnt=256)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
-
-  def data(self) -> list[CollectionTable]:
-    return [
+    def data(self) -> list[CollectionTable]:
+        return [
             TraceMMRSSStatDataTable.from_df_id(
                 pl.DataFrame(self.trace_rss_stat),
                 collection_id=self.collection_id,
             ),
         ]
 
-  def clear(self):
-    self.trace_rss_stat.clear()
+    def clear(self):
+        self.trace_rss_stat.clear()
 
-  def pop_data(self) -> list[CollectionTable]:
-    quanta_tables = self.data()
-    self.clear()
-    return quanta_tables
+    def pop_data(self) -> list[CollectionTable]:
+        quanta_tables = self.data()
+        self.clear()
+        return quanta_tables
 
-  def _mm_trace_rss_stat_eh(self, cpu, rss_stat_struct, size):
-      event = self.bpf["rss_stat_output"].event(rss_stat_struct)
-      self.trace_rss_stat.append(
-        TraceRSSStat(
-          pid=event.pid,
-          tgid=event.tgid,
-          ts_ns=event.ts,
-          member=MEMBER_ASSIGN_ARR[event.member],
-          count=event.counter_value,
+    def _mm_trace_rss_stat_eh(self, cpu, rss_stat_struct, size):
+        event = self.bpf["rss_stat_output"].event(rss_stat_struct)
+        self.trace_rss_stat.append(
+            TraceRSSStat(
+                pid=event.pid,
+                tgid=event.tgid,
+                ts_ns=event.ts,
+                member=MEMBER_ASSIGN_ARR[event.member],
+                count=event.counter_value,
+            )
         )
-      )

--- a/python/kernmlops/data_collection/bpf_instrumentation/perf/__init__.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/perf/__init__.py
@@ -2,6 +2,6 @@ from data_collection.bpf_instrumentation.perf.perf_config import CustomHWConfigM
 from data_collection.bpf_instrumentation.perf.perf_hook import PerfBPFHook
 
 __all__ = [
-  "CustomHWConfigManager",
-  "PerfBPFHook",
+    "CustomHWConfigManager",
+    "PerfBPFHook",
 ]

--- a/python/kernmlops/data_collection/bpf_instrumentation/perf/perf_config.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/perf/perf_config.py
@@ -9,70 +9,67 @@ from data_schema.perf import CustomHWEventID, PerfCollectionTable
 
 # https://stackoverflow.com/questions/14626395/how-to-properly-convert-a-c-ioctl-call-to-a-python-fcntl-ioctl-call
 # https://github.com/torvalds/linux/blob/0a9b9d17f3a781dea03baca01c835deaa07f7cc3/include/uapi/linux/perf_event.h#L551
-PERF_EVENT_IOC_ENABLE: Final[int] = ord('$') << (4*2) | 0
-PERF_EVENT_IOC_DISABLE: Final[int] = ord('$') << (4*2) | 1
+PERF_EVENT_IOC_ENABLE: Final[int] = ord("$") << (4 * 2) | 0
+PERF_EVENT_IOC_DISABLE: Final[int] = ord("$") << (4 * 2) | 1
 PERF_IOC_FLAG_GROUP: Final[int] = 1
 
 
 @dataclass(frozen=True)
 class CustomHWConfigUmask:
-  id: str
-  code: int
-  source: str
-  name: str
-  # flags are actually a list of strings if present
-  flags: str | None
-  description: str
+    id: str
+    code: int
+    source: str
+    name: str
+    # flags are actually a list of strings if present
+    flags: str | None
+    description: str
 
-  def dump(self) -> str:
-    return f"{self.id} : {self.code} : {self.source} : {self.name} : {self.flags} : {self.description}"
+    def dump(self) -> str:
+        return f"{self.id} : {self.code} : {self.source} : {self.name} : {self.flags} : {self.description}"
 
-  @classmethod
-  def from_evtline(cls, evt_line: str) -> "CustomHWConfigUmask | None":
-    fields = [
-      field.lstrip().rstrip()
-      for field in evt_line.split(":")
-    ]
-    if len(fields) < 6:
-      return None
-    return CustomHWConfigUmask(
-      id=fields[0],
-      code=int(fields[1], base=0),
-      source=fields[2],
-      name=fields[3][1:-1],
-      flags=fields[4],
-      description=fields[5],
-    )
+    @classmethod
+    def from_evtline(cls, evt_line: str) -> "CustomHWConfigUmask | None":
+        fields = [field.lstrip().rstrip() for field in evt_line.split(":")]
+        if len(fields) < 6:
+            return None
+        return CustomHWConfigUmask(
+            id=fields[0],
+            code=int(fields[1], base=0),
+            source=fields[2],
+            name=fields[3][1:-1],
+            flags=fields[4],
+            description=fields[5],
+        )
 
 
 @dataclass(frozen=True)
 class CustomHWConfig:
-  id: int
-  pmu_name: str
-  name: str
-  equiv: str | None
-  # flags are actually a list of strings if present
-  flags: str | None
-  description: str
-  code: int
-  code_length_hex: int
-  umasks: Mapping[str, CustomHWConfigUmask]
-  # modifier entries are actually objects, not strings
-  modifiers: list[str]
+    id: int
+    pmu_name: str
+    name: str
+    equiv: str | None
+    # flags are actually a list of strings if present
+    flags: str | None
+    description: str
+    code: int
+    code_length_hex: int
+    umasks: Mapping[str, CustomHWConfigUmask]
+    # modifier entries are actually objects, not strings
+    modifiers: list[str]
 
-  def config(self, id: CustomHWEventID) -> int | None:
-    if id.name.upper() != self.name:
-      return None
-    if id.umask is None:
-      return self.code
-    umask = self.umasks.get(id.umask.upper())
-    if umask is None:
-      return None
-    # TODO(Patrick): confirm this left shift for Umasks works everywhere
-    return (self.code) | (umask.code << (4 * self.code_length_hex))
+    def config(self, id: CustomHWEventID) -> int | None:
+        if id.name.upper() != self.name:
+            return None
+        if id.umask is None:
+            return self.code
+        umask = self.umasks.get(id.umask.upper())
+        if umask is None:
+            return None
+        # TODO(Patrick): confirm this left shift for Umasks works everywhere
+        return (self.code) | (umask.code << (4 * self.code_length_hex))
 
-  def dump(self) -> str:
-    return f"""
+    def dump(self) -> str:
+        return f"""
 #-----------------------------
 IDX : {self.id}
 PMU name : {self.pmu_name}
@@ -81,125 +78,132 @@ Equiv : {self.equiv}
 Flags : {self.flags}
 Desc : {self.description}
 Code : {self.code}
-{"\n".join([
-  umask.dump()
-  for umask in self.umasks.values()
-])}
+{"\n".join([umask.dump() for umask in self.umasks.values()])}
 {"\n".join(self.modifiers)}
 """
 
-  @classmethod
-  def from_evtinfo(cls, evt_lines: list[str]) -> "CustomHWConfig | None":
-    id: int | None = None
-    pmu_name: str | None = None
-    name: str | None = None
-    equiv: str | None = None
-    flags: str | None = None
-    description: str | None = None
-    code: int | None = None
-    code_length_hex: int = 2
-    umasks = dict[str, CustomHWConfigUmask]()
-    modifiers = list[str]()
+    @classmethod
+    def from_evtinfo(cls, evt_lines: list[str]) -> "CustomHWConfig | None":
+        id: int | None = None
+        pmu_name: str | None = None
+        name: str | None = None
+        equiv: str | None = None
+        flags: str | None = None
+        description: str | None = None
+        code: int | None = None
+        code_length_hex: int = 2
+        umasks = dict[str, CustomHWConfigUmask]()
+        modifiers = list[str]()
 
-    for evt_line in evt_lines:
-      if not evt_line:
-        continue
-      split_line = evt_line.split(":", maxsplit=1)
-      if len(split_line) != 2:
-        continue
-      key = split_line[0]
-      value = split_line[1]
-      key = key.lstrip().rstrip()
-      value = value.lstrip().rstrip()
-      match key:
-        case "IDX":
-          id = int(value)
-        case "PMU name":
-          pmu_name = value
-        case "Name":
-          name = value.upper()
-        case "Equiv":
-          equiv = None if value == "None" else value
-        case "Flags":
-          flags = None if value == "None" else value
-        case "Desc":
-          description = value
-        case "Code":
-          code = int(value, base=0)
-          code_length_hex = len(value) - 2
-      if key.startswith("Umask"):
-        umask = CustomHWConfigUmask.from_evtline(evt_line)
-        if umask is not None:
-          umasks[umask.name.upper()] = umask
-        else:
-          print("warning: could not parse a hardware event's umask info")
-          print(evt_line)
-          return None
-      if key.startswith("Modif"):
-        modifiers.append(evt_line)
-    if id is None or pmu_name is None or name is None or description is None or code is None:
-      print("warning: could not parse a hardware event's info")
-      print(evt_lines)
-      return None
-    return CustomHWConfig(
-      id=id,
-      pmu_name=pmu_name,
-      name=name,
-      equiv=equiv,
-      flags=flags,
-      description=description,
-      code=code,
-      code_length_hex=code_length_hex,
-      umasks=umasks,
-      modifiers=modifiers,
-    )
+        for evt_line in evt_lines:
+            if not evt_line:
+                continue
+            split_line = evt_line.split(":", maxsplit=1)
+            if len(split_line) != 2:
+                continue
+            key = split_line[0]
+            value = split_line[1]
+            key = key.lstrip().rstrip()
+            value = value.lstrip().rstrip()
+            match key:
+                case "IDX":
+                    id = int(value)
+                case "PMU name":
+                    pmu_name = value
+                case "Name":
+                    name = value.upper()
+                case "Equiv":
+                    equiv = None if value == "None" else value
+                case "Flags":
+                    flags = None if value == "None" else value
+                case "Desc":
+                    description = value
+                case "Code":
+                    code = int(value, base=0)
+                    code_length_hex = len(value) - 2
+            if key.startswith("Umask"):
+                umask = CustomHWConfigUmask.from_evtline(evt_line)
+                if umask is not None:
+                    umasks[umask.name.upper()] = umask
+                else:
+                    print("warning: could not parse a hardware event's umask info")
+                    print(evt_line)
+                    return None
+            if key.startswith("Modif"):
+                modifiers.append(evt_line)
+        if (
+            id is None
+            or pmu_name is None
+            or name is None
+            or description is None
+            or code is None
+        ):
+            print("warning: could not parse a hardware event's info")
+            print(evt_lines)
+            return None
+        return CustomHWConfig(
+            id=id,
+            pmu_name=pmu_name,
+            name=name,
+            equiv=equiv,
+            flags=flags,
+            description=description,
+            code=code,
+            code_length_hex=code_length_hex,
+            umasks=umasks,
+            modifiers=modifiers,
+        )
 
 
 class CustomHWConfigManager:
-  @classmethod
-  @cache
-  def hw_event_map(cls) -> Mapping[str, CustomHWConfig]:
-    hw_events = dict[str, CustomHWConfig]()
-    pfm4_dir = os.environ.get("LIB_PFM4_DIR")
-    if not pfm4_dir:
-      # TODO(Patrick): make this a warning
-      print("warning: LIB_PFM4_DIR has not been set, disabling custom perf counters")
-      return hw_events
-    showevtinfo = Path(pfm4_dir) / "examples" / "showevtinfo"
-    if not showevtinfo.is_file():
-      print("warning: libpfm4 has not been properly built, disabling custom perf counters")
-      return hw_events
-    raw_event_info = subprocess.check_output(str(showevtinfo))
-    if isinstance(raw_event_info, bytes):
-      raw_event_info = raw_event_info.decode("utf-8")
-    if not isinstance(raw_event_info, str):
-      return hw_events
-    raw_event_info = raw_event_info.lstrip().rstrip()
-    events_info = raw_event_info.split("#-----------------------------\n")
-    if events_info:
-      events_info = events_info[1:]
-    for event_info in events_info:
-      hw_config = CustomHWConfig.from_evtinfo(event_info.splitlines())
-      if hw_config is not None:
-        hw_events[hw_config.name] = hw_config
-    return hw_events
+    @classmethod
+    @cache
+    def hw_event_map(cls) -> Mapping[str, CustomHWConfig]:
+        hw_events = dict[str, CustomHWConfig]()
+        pfm4_dir = os.environ.get("LIB_PFM4_DIR")
+        if not pfm4_dir:
+            # TODO(Patrick): make this a warning
+            print(
+                "warning: LIB_PFM4_DIR has not been set, disabling custom perf counters"
+            )
+            return hw_events
+        showevtinfo = Path(pfm4_dir) / "examples" / "showevtinfo"
+        if not showevtinfo.is_file():
+            print(
+                "warning: libpfm4 has not been properly built, disabling custom perf counters"
+            )
+            return hw_events
+        raw_event_info = subprocess.check_output(str(showevtinfo))
+        if isinstance(raw_event_info, bytes):
+            raw_event_info = raw_event_info.decode("utf-8")
+        if not isinstance(raw_event_info, str):
+            return hw_events
+        raw_event_info = raw_event_info.lstrip().rstrip()
+        events_info = raw_event_info.split("#-----------------------------\n")
+        if events_info:
+            events_info = events_info[1:]
+        for event_info in events_info:
+            hw_config = CustomHWConfig.from_evtinfo(event_info.splitlines())
+            if hw_config is not None:
+                hw_events[hw_config.name] = hw_config
+        return hw_events
 
-  @classmethod
-  def get_hw_event(cls, event: type[PerfCollectionTable]) -> CustomHWConfig | None:
-    for hw_id in event.hw_ids():
-      hw_event_config = cls.hw_event_map().get(hw_id.name.upper())
-      if hw_event_config is not None:
-        hw_config_value = hw_event_config.config(hw_id)
-        if hw_config_value is not None:
-          return hw_event_config
-    return None
+    @classmethod
+    def get_hw_event(cls, event: type[PerfCollectionTable]) -> CustomHWConfig | None:
+        for hw_id in event.hw_ids():
+            hw_event_config = cls.hw_event_map().get(hw_id.name.upper())
+            if hw_event_config is not None:
+                hw_config_value = hw_event_config.config(hw_id)
+                if hw_config_value is not None:
+                    return hw_event_config
+        return None
 
-  @classmethod
-  def get_hw_config(cls, event: type[PerfCollectionTable]) -> int | None:
-    for hw_id in event.hw_ids():
-      hw_event_config = cls.hw_event_map().get(hw_id.name.upper())
-      if hw_event_config is not None:
-        hw_config_value = hw_event_config.config(hw_id)
-        if hw_config_value is not None:
-          return hw_config_value
-    return None
+    @classmethod
+    def get_hw_config(cls, event: type[PerfCollectionTable]) -> int | None:
+        for hw_id in event.hw_ids():
+            hw_event_config = cls.hw_event_map().get(hw_id.name.upper())
+            if hw_event_config is not None:
+                hw_config_value = hw_event_config.config(hw_id)
+                if hw_config_value is not None:
+                    return hw_config_value
+        return None

--- a/python/kernmlops/data_collection/bpf_instrumentation/perf/perf_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/perf/perf_hook.py
@@ -7,10 +7,10 @@ import polars as pl
 from bcc import BPF, PerfType
 from data_collection.bpf_instrumentation.bpf_hook import POLL_TIMEOUT_MS, BPFProgram
 from data_collection.bpf_instrumentation.perf.perf_config import (
-  PERF_EVENT_IOC_DISABLE,
-  PERF_EVENT_IOC_ENABLE,
-  PERF_IOC_FLAG_GROUP,
-  CustomHWConfigManager,
+    PERF_EVENT_IOC_DISABLE,
+    PERF_EVENT_IOC_ENABLE,
+    PERF_IOC_FLAG_GROUP,
+    CustomHWConfigManager,
 )
 from data_schema import CollectionTable
 from data_schema.perf import PerfCollectionTable, perf_table_types
@@ -38,144 +38,148 @@ int NAME_on(struct bpf_perf_event_data* ctx) {
 }
 """
 
+
 @dataclass(frozen=True)
 class PerfData:
-  cpu: int
-  pid: int
-  tgid: int
-  ts_uptime_us: int
-  cumulative_count: int
-  pmu_enabled_time_us: int
-  pmu_running_time_us: int
+    cpu: int
+    pid: int
+    tgid: int
+    ts_uptime_us: int
+    cumulative_count: int
+    pmu_enabled_time_us: int
+    pmu_running_time_us: int
 
-  @classmethod
-  def from_event(cls, cpu: int, event: Any):
-    return PerfData(
-        cpu=cpu,
-        pid=event.pid,
-        tgid=event.tgid,
-        ts_uptime_us=event.ts_uptime_us,
-        cumulative_count=event.count,
-        pmu_enabled_time_us=event.enabled_time_us,
-        pmu_running_time_us=event.running_time_us,
-    )
-
-
-class PerfBPFHook(BPFProgram):
-
-  @classmethod
-  def name(cls) -> str:
-    return "perf"
-
-  def __init__(self):
-    self._perf_data = dict[str, list[PerfData]]()
-    self.bpf_text = open(Path(__file__).parent / "../bpf/perf.bpf.c", "r").read()
-    self.loaded_hw_event_configs = dict[type[PerfCollectionTable], int]()
-    self.group_fds: dict[int, int] | None = None
-
-    # add perf handlers
-    def init_perf_handler(perf_event: type[PerfCollectionTable]):
-      if perf_event.ev_type() == PerfType.RAW:
-        hw_config_value = CustomHWConfigManager.get_hw_config(perf_event)
-        if hw_config_value is not None:
-          self.bpf_text += PERF_HANDLER.replace("NAME", perf_event.name())
-          self._perf_data[perf_event.name()] = list[PerfData]()
-          self.loaded_hw_event_configs[perf_event] = hw_config_value
-        else:
-          print(f"info: could not enable perf counter for {perf_event.name()}")
-      else:
-        self.bpf_text += PERF_HANDLER.replace("NAME", perf_event.name())
-        self._perf_data[perf_event.name()] = list[PerfData]()
-        self.loaded_hw_event_configs[perf_event] = perf_event.ev_config()
-
-    for perf_event in list(perf_table_types.values()):
-      init_perf_handler(perf_event)
-
-  def _attach_perf_event(
-      self,
-      ev_type: int,
-      ev_config: int,
-      fn_name: bytes,
-      sample_freq: int,
-  ) -> None:
-    if self.group_fds is None:
-      self.bpf.attach_perf_event(
-        ev_type=ev_type,
-        ev_config=ev_config,
-        fn_name=fn_name,
-        sample_freq=sample_freq,
-        cpu=-1,
-        group_fd=-1,
-      )
-      self.group_fds = self.bpf.open_perf_events[(ev_type, ev_config)]
-    else:
-      for cpu, group_fd in self.group_fds.items():
-        self.bpf.attach_perf_event(
-          ev_type=ev_type,
-          ev_config=ev_config,
-          fn_name=fn_name,
-          sample_freq=sample_freq,
-          cpu=cpu,
-          group_fd=group_fd,
+    @classmethod
+    def from_event(cls, cpu: int, event: Any):
+        return PerfData(
+            cpu=cpu,
+            pid=event.pid,
+            tgid=event.tgid,
+            ts_uptime_us=event.ts_uptime_us,
+            cumulative_count=event.count,
+            pmu_enabled_time_us=event.enabled_time_us,
+            pmu_running_time_us=event.running_time_us,
         )
 
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    # sample frequency is in hertz
-    for event, hw_config in self.loaded_hw_event_configs.items():
-      self._attach_perf_event(
-        ev_type=event.ev_type(),
-        ev_config=hw_config,
-        fn_name=bytes(f"{str(event.name())}_on", encoding="utf-8"),
-        sample_freq=1000,
-      )
-    for event_name in self._perf_data.keys():
-      self.bpf[event_name].open_perf_buffer(self._perf_handler(event_name), page_cnt=64)
+class PerfBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "perf"
 
-  def disable_counters(self) -> None:
-    if self.group_fds is None:
-      return
-    for _, group_fd in self.group_fds.items():
-      ioctl(group_fd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP)
+    def __init__(self):
+        self._perf_data = dict[str, list[PerfData]]()
+        self.bpf_text = open(Path(__file__).parent / "../bpf/perf.bpf.c", "r").read()
+        self.loaded_hw_event_configs = dict[type[PerfCollectionTable], int]()
+        self.group_fds: dict[int, int] | None = None
 
-  def enable_counters(self) -> None:
-    if self.group_fds is None:
-      return
-    for _, group_fd in self.group_fds.items():
-      ioctl(group_fd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP)
+        # add perf handlers
+        def init_perf_handler(perf_event: type[PerfCollectionTable]):
+            if perf_event.ev_type() == PerfType.RAW:
+                hw_config_value = CustomHWConfigManager.get_hw_config(perf_event)
+                if hw_config_value is not None:
+                    self.bpf_text += PERF_HANDLER.replace("NAME", perf_event.name())
+                    self._perf_data[perf_event.name()] = list[PerfData]()
+                    self.loaded_hw_event_configs[perf_event] = hw_config_value
+                else:
+                    print(
+                        f"info: could not enable perf counter for {perf_event.name()}"
+                    )
+            else:
+                self.bpf_text += PERF_HANDLER.replace("NAME", perf_event.name())
+                self._perf_data[perf_event.name()] = list[PerfData]()
+                self.loaded_hw_event_configs[perf_event] = perf_event.ev_config()
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+        for perf_event in list(perf_table_types.values()):
+            init_perf_handler(perf_event)
 
-  def close(self):
-    self.bpf.cleanup()
+    def _attach_perf_event(
+        self,
+        ev_type: int,
+        ev_config: int,
+        fn_name: bytes,
+        sample_freq: int,
+    ) -> None:
+        if self.group_fds is None:
+            self.bpf.attach_perf_event(
+                ev_type=ev_type,
+                ev_config=ev_config,
+                fn_name=fn_name,
+                sample_freq=sample_freq,
+                cpu=-1,
+                group_fd=-1,
+            )
+            self.group_fds = self.bpf.open_perf_events[(ev_type, ev_config)]
+        else:
+            for cpu, group_fd in self.group_fds.items():
+                self.bpf.attach_perf_event(
+                    ev_type=ev_type,
+                    ev_config=ev_config,
+                    fn_name=fn_name,
+                    sample_freq=sample_freq,
+                    cpu=cpu,
+                    group_fd=group_fd,
+                )
 
-  def data(self) -> list[CollectionTable]:
-    return [
-      perf_table_types[event_name].from_df_id(
-        pl.DataFrame(self._perf_data[event_name]),
-        collection_id=self.collection_id,
-      )
-      for event_name in self._perf_data.keys()
-      if event_name in perf_table_types and len(self._perf_data[event_name]) > 0
-    ]
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        # sample frequency is in hertz
+        for event, hw_config in self.loaded_hw_event_configs.items():
+            self._attach_perf_event(
+                ev_type=event.ev_type(),
+                ev_config=hw_config,
+                fn_name=bytes(f"{str(event.name())}_on", encoding="utf-8"),
+                sample_freq=1000,
+            )
+        for event_name in self._perf_data.keys():
+            self.bpf[event_name].open_perf_buffer(
+                self._perf_handler(event_name), page_cnt=64
+            )
 
-  def clear(self):
-    for key in self._perf_data.keys():
-      self._perf_data[key].clear()
+    def disable_counters(self) -> None:
+        if self.group_fds is None:
+            return
+        for _, group_fd in self.group_fds.items():
+            ioctl(group_fd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP)
 
-  def pop_data(self) -> list[CollectionTable]:
-    miss_tables = self.data()
-    self.clear()
-    return miss_tables
+    def enable_counters(self) -> None:
+        if self.group_fds is None:
+            return
+        for _, group_fd in self.group_fds.items():
+            ioctl(group_fd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP)
 
-  def _perf_handler(self, event_name: str):
-    def _perf_event_handler(cpu, perf_event_data, size):
-      event = self.bpf[event_name].event(perf_event_data)
-      try:
-          self._perf_data[event_name].append(PerfData.from_event(cpu, event))
-      except Exception as _:
-        pass
-    return _perf_event_handler
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+
+    def close(self):
+        self.bpf.cleanup()
+
+    def data(self) -> list[CollectionTable]:
+        return [
+            perf_table_types[event_name].from_df_id(
+                pl.DataFrame(self._perf_data[event_name]),
+                collection_id=self.collection_id,
+            )
+            for event_name in self._perf_data.keys()
+            if event_name in perf_table_types and len(self._perf_data[event_name]) > 0
+        ]
+
+    def clear(self):
+        for key in self._perf_data.keys():
+            self._perf_data[key].clear()
+
+    def pop_data(self) -> list[CollectionTable]:
+        miss_tables = self.data()
+        self.clear()
+        return miss_tables
+
+    def _perf_handler(self, event_name: str):
+        def _perf_event_handler(cpu, perf_event_data, size):
+            event = self.bpf[event_name].event(perf_event_data)
+            try:
+                self._perf_data[event_name].append(PerfData.from_event(cpu, event))
+            except Exception as _:
+                pass
+
+        return _perf_event_handler

--- a/python/kernmlops/data_collection/bpf_instrumentation/process_metadata_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/process_metadata_hook.py
@@ -16,89 +16,92 @@ from osquery.extensions.ttypes import ExtensionStatus
 
 @dataclass(frozen=True)
 class ProcessMetadata:
-  pid: int
-  name: str
-  cmdline: str
-  start_time: int
-  parent: int
-  nice: int
-  cgroup_path: str
+    pid: int
+    name: str
+    cmdline: str
+    start_time: int
+    parent: int
+    nice: int
+    cgroup_path: str
+
 
 class ProcessMetadataHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "process_metadata"
 
-  @classmethod
-  def name(cls) -> str:
-    return "process_metadata"
+    @classmethod
+    @cache
+    def _select_columns(cls) -> list[str]:
+        return [field.name for field in fields(ProcessMetadata)]
 
-  @classmethod
-  @cache
-  def _select_columns(cls) -> list[str]:
-    return [field.name for field in fields(ProcessMetadata)]
+    @classmethod
+    @cache
+    def _query_select_columns(cls) -> str:
+        return ", ".join(cls._select_columns())
 
-  @classmethod
-  @cache
-  def _query_select_columns(cls) -> str:
-    return ", ".join(cls._select_columns())
+    def __init__(self):
+        self.collector_pid = os.getpid()
+        self.process_metadata = list[Mapping[str, Any]]()
 
-  def __init__(self):
-    self.collector_pid = os.getpid()
-    self.process_metadata = list[Mapping[str, Any]]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.osquery_instance = osquery.SpawnInstance()
+        self.osquery_instance.open()
+        self.osquery_client = self.osquery_instance.client
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.osquery_instance = osquery.SpawnInstance()
-    self.osquery_instance.open()
-    self.osquery_client = self.osquery_instance.client
+        initial_processes_query = self.osquery_client.query(
+            f"SELECT {self._query_select_columns()} FROM processes"
+        )
+        # TODO(Patrick): Add error handling
+        assert isinstance(initial_processes_query.status, ExtensionStatus)
+        assert initial_processes_query.status.code == 0
+        assert isinstance(initial_processes_query.response, list)
+        self.process_metadata = initial_processes_query.response
 
-    initial_processes_query = self.osquery_client.query(
-      f"SELECT {self._query_select_columns()} FROM processes"
-    )
-    # TODO(Patrick): Add error handling
-    assert isinstance(initial_processes_query.status, ExtensionStatus)
-    assert initial_processes_query.status.code == 0
-    assert isinstance(initial_processes_query.response, list)
-    self.process_metadata = initial_processes_query.response
+    def poll(self):
+        new_processes_query = self.osquery_client.query(
+            f"SELECT {self._query_select_columns()} FROM processes WHERE pid > {self.collector_pid}"
+        )
+        # TODO(Patrick): Add error handling
+        assert isinstance(new_processes_query.status, ExtensionStatus)
+        assert new_processes_query.status.code == 0
+        assert isinstance(new_processes_query.response, list)
+        self.process_metadata.extend(new_processes_query.response)
 
-  def poll(self):
-    new_processes_query = self.osquery_client.query(
-      f"SELECT {self._query_select_columns()} FROM processes WHERE pid > {self.collector_pid}"
-    )
-    # TODO(Patrick): Add error handling
-    assert isinstance(new_processes_query.status, ExtensionStatus)
-    assert new_processes_query.status.code == 0
-    assert isinstance(new_processes_query.response, list)
-    self.process_metadata.extend(new_processes_query.response)
+    def close(self):
+        self.osquery_instance.instance.send_signal(signal.SIGINT)  # pyright: ignore [reportOptionalMemberAccess]
+        self.osquery_instance.instance.wait()  # pyright: ignore [reportOptionalMemberAccess]
 
-  def close(self):
-    self.osquery_instance.instance.send_signal(signal.SIGINT)  # pyright: ignore [reportOptionalMemberAccess]
-    self.osquery_instance.instance.wait()  # pyright: ignore [reportOptionalMemberAccess]
+    def data(self) -> list[CollectionTable]:
+        if len(self.process_metadata) == 0:
+            return []
+        return [
+            ProcessMetadataTable.from_df_id(
+                pl.DataFrame(self.process_metadata)
+                .unique("pid")
+                .cast(
+                    {
+                        "pid": pl.Int64(),
+                        "start_time": pl.Int64(),
+                        "parent": pl.Int64(),
+                        "nice": pl.Int64(),
+                    }
+                )
+                .rename(
+                    {
+                        "parent": "parent_pid",
+                        "start_time": "start_time_unix_sec",
+                    }
+                ),
+                collection_id=self.collection_id,
+            )
+        ]
 
-  def data(self) -> list[CollectionTable]:
-    if len(self.process_metadata) == 0:
-        return []
-    return [
-      ProcessMetadataTable.from_df_id(
-        pl.DataFrame(
-          self.process_metadata
-        ).unique(
-          "pid"
-        ).cast({
-          "pid": pl.Int64(),
-          "start_time": pl.Int64(),
-          "parent": pl.Int64(),
-          "nice": pl.Int64(),
-        }).rename({
-          "parent": "parent_pid",
-          "start_time": "start_time_unix_sec",
-        }),
-        collection_id=self.collection_id,
-      )
-    ]
+    def clear(self):
+        self.process_metadata.clear()
 
-  def clear(self):
-    self.process_metadata.clear()
-
-  def pop_data(self) -> list[CollectionTable]:
-    process_table = self.data()
-    self.clear()
-    return process_table
+    def pop_data(self) -> list[CollectionTable]:
+        process_table = self.data()
+        self.clear()
+        return process_table

--- a/python/kernmlops/data_collection/bpf_instrumentation/quanta_runtime_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/quanta_runtime_hook.py
@@ -10,104 +10,119 @@ from data_schema.quanta_runtime import QuantaQueuedTable, QuantaRuntimeTable
 # Note: collecting blocked time is not useful since parent processes blocking on children
 # obfuscates the meaning
 
+
 @dataclass(frozen=True)
 class QuantaRuntimeData:
-  cpu: int
-  pid: int
-  tgid: int
-  quanta_end_uptime_us: int
-  quanta_run_length_us: int
+    cpu: int
+    pid: int
+    tgid: int
+    quanta_end_uptime_us: int
+    quanta_run_length_us: int
+
 
 class QuantaRuntimeBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "quanta_runtime"
 
-  @classmethod
-  def name(cls) -> str:
-    return "quanta_runtime"
+    def __init__(self):
+        self.is_support_raw_tp = False  #  BPF.support_raw_tracepoint()
+        bpf_text = open(
+            Path(__file__).parent / "bpf/sched_quanta_runtime.bpf.c", "r"
+        ).read()
 
-  def __init__(self):
-    self.is_support_raw_tp = False #  BPF.support_raw_tracepoint()
-    bpf_text = open(Path(__file__).parent / "bpf/sched_quanta_runtime.bpf.c", "r").read()
+        # code substitutions
+        if BPF.kernel_struct_has_field(b"task_struct", b"__state") == 1:
+            bpf_text = bpf_text.replace("STATE_FIELD", "__state")
+        else:
+            bpf_text = bpf_text.replace("STATE_FIELD", "state")
+        # pid from userspace point of view is thread group from kernel pov
+        # bpf_text = bpf_text.replace('FILTER', 'tgid != %s' % args.pid)
+        self.bpf_text = bpf_text.replace("FILTER", "0")
+        if self.is_support_raw_tp:
+            bpf_text = bpf_text.replace("USE_TRACEPOINT", "1")
+        else:
+            bpf_text = bpf_text.replace("USE_TRACEPOINT", "0")
+        self.quanta_runtime_data = list[QuantaRuntimeData]()
+        self.quanta_queue_data = list[QuantaRuntimeData]()
 
-    # code substitutions
-    if BPF.kernel_struct_has_field(b'task_struct', b'__state') == 1:
-        bpf_text = bpf_text.replace('STATE_FIELD', '__state')
-    else:
-        bpf_text = bpf_text.replace('STATE_FIELD', 'state')
-    # pid from userspace point of view is thread group from kernel pov
-    # bpf_text = bpf_text.replace('FILTER', 'tgid != %s' % args.pid)
-    self.bpf_text = bpf_text.replace('FILTER', '0')
-    if self.is_support_raw_tp:
-        bpf_text = bpf_text.replace('USE_TRACEPOINT', '1')
-    else:
-        bpf_text = bpf_text.replace('USE_TRACEPOINT', '0')
-    self.quanta_runtime_data = list[QuantaRuntimeData]()
-    self.quanta_queue_data = list[QuantaRuntimeData]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        if not self.is_support_raw_tp:
+            self.bpf.attach_kprobe(
+                event=b"ttwu_do_activate", fn_name=b"trace_ttwu_do_wakeup"
+            )
+            self.bpf.attach_kprobe(
+                event=b"wake_up_new_task", fn_name=b"trace_wake_up_new_task"
+            )
+            self.bpf.attach_kprobe(
+                event_re=rb"^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                fn_name=b"trace_run",
+            )
+        self.bpf["quanta_runtimes"].open_perf_buffer(
+            self._runtime_event_handler, page_cnt=64
+        )
+        self.bpf["quanta_queue_times"].open_perf_buffer(
+            self._queue_event_handler, page_cnt=64
+        )
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    if not self.is_support_raw_tp:
-      self.bpf.attach_kprobe(event=b"ttwu_do_activate", fn_name=b"trace_ttwu_do_wakeup")
-      self.bpf.attach_kprobe(event=b"wake_up_new_task", fn_name=b"trace_wake_up_new_task")
-      self.bpf.attach_kprobe(
-        event_re=rb'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
-        fn_name=b"trace_run"
-      )
-    self.bpf["quanta_runtimes"].open_perf_buffer(self._runtime_event_handler, page_cnt=64)
-    self.bpf["quanta_queue_times"].open_perf_buffer(self._queue_event_handler, page_cnt=64)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
+    def data(self) -> list[CollectionTable]:
+        return [
+            QuantaRuntimeTable.from_df_id(
+                pl.DataFrame(self.quanta_runtime_data).rename(
+                    {
+                        "quanta_end_uptime_us": UPTIME_TIMESTAMP,
+                    }
+                ),
+                collection_id=self.collection_id,
+            ),
+            QuantaQueuedTable.from_df_id(
+                pl.DataFrame(self.quanta_queue_data).rename(
+                    {
+                        "quanta_end_uptime_us": UPTIME_TIMESTAMP,
+                        "quanta_run_length_us": "quanta_queued_time_us",
+                    }
+                ),
+                collection_id=self.collection_id,
+            ),
+        ]
 
-  def data(self) -> list[CollectionTable]:
-    return [
-      QuantaRuntimeTable.from_df_id(
-        pl.DataFrame(self.quanta_runtime_data).rename({
-          "quanta_end_uptime_us": UPTIME_TIMESTAMP,
-        }),
-        collection_id=self.collection_id,
-      ),
-      QuantaQueuedTable.from_df_id(
-        pl.DataFrame(self.quanta_queue_data).rename({
-          "quanta_end_uptime_us": UPTIME_TIMESTAMP,
-          "quanta_run_length_us": "quanta_queued_time_us",
-        }),
-        collection_id=self.collection_id,
-      )
-    ]
+    def clear(self):
+        self.quanta_runtime_data.clear()
+        self.quanta_queue_data.clear()
 
-  def clear(self):
-    self.quanta_runtime_data.clear()
-    self.quanta_queue_data.clear()
+    def pop_data(self) -> list[CollectionTable]:
+        quanta_tables = self.data()
+        self.clear()
+        return quanta_tables
 
-  def pop_data(self) -> list[CollectionTable]:
-    quanta_tables = self.data()
-    self.clear()
-    return quanta_tables
+    def _runtime_event_handler(self, cpu, quanta_runtime_perf_event, size):
+        event = self.bpf["quanta_runtimes"].event(quanta_runtime_perf_event)
+        self.quanta_runtime_data.append(
+            QuantaRuntimeData(
+                cpu=cpu,
+                pid=event.pid,
+                tgid=event.tgid,
+                quanta_end_uptime_us=event.quanta_end_uptime_us,
+                quanta_run_length_us=event.quanta_run_length_us,
+            )
+        )
 
-  def _runtime_event_handler(self, cpu, quanta_runtime_perf_event, size):
-    event = self.bpf["quanta_runtimes"].event(quanta_runtime_perf_event)
-    self.quanta_runtime_data.append(
-      QuantaRuntimeData(
-        cpu=cpu,
-        pid=event.pid,
-        tgid=event.tgid,
-        quanta_end_uptime_us=event.quanta_end_uptime_us,
-        quanta_run_length_us=event.quanta_run_length_us,
-      )
-    )
-
-  def _queue_event_handler(self, cpu, quanta_runtime_perf_event, size):
-    event = self.bpf["quanta_queue_times"].event(quanta_runtime_perf_event)
-    self.quanta_queue_data.append(
-      QuantaRuntimeData(
-        cpu=cpu,
-        pid=event.pid,
-        tgid=event.tgid,
-        quanta_end_uptime_us=event.quanta_end_uptime_us,
-        quanta_run_length_us=event.quanta_run_length_us,
-      )
-    )
+    def _queue_event_handler(self, cpu, quanta_runtime_perf_event, size):
+        event = self.bpf["quanta_queue_times"].event(quanta_runtime_perf_event)
+        self.quanta_queue_data.append(
+            QuantaRuntimeData(
+                cpu=cpu,
+                pid=event.pid,
+                tgid=event.tgid,
+                quanta_end_uptime_us=event.quanta_end_uptime_us,
+                quanta_run_length_us=event.quanta_run_length_us,
+            )
+        )

--- a/python/kernmlops/data_collection/bpf_instrumentation/unmap_range.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/unmap_range.py
@@ -10,60 +10,68 @@ from data_schema.generic_table import UnmapRangeDataTable
 
 @dataclass(frozen=True)
 class UnmapRangeStat:
-  tgid: int
-  ts_ns: int
-  start: int
-  end: int
-  is_huge: bool
+    tgid: int
+    ts_ns: int
+    start: int
+    end: int
+    is_huge: bool
+
 
 class UnmapRangeBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "unmap_range"
 
-  @classmethod
-  def name(cls) -> str:
-    return "unmap_range"
+    def __init__(self):
+        self.is_support_raw_tp = True  #  BPF.support_raw_tracepoint()
+        self.bpf_text = open(
+            Path(__file__).parent / "bpf/unmap_range.bpf.c", "r"
+        ).read()
+        self.unmap_range_stat = list[UnmapRangeStat]()
 
-  def __init__(self):
-    self.is_support_raw_tp = True #  BPF.support_raw_tracepoint()
-    self.bpf_text = open(Path(__file__).parent / "bpf/unmap_range.bpf.c", "r").read()
-    self.unmap_range_stat = list[UnmapRangeStat]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        self.bpf.attach_kprobe(
+            event=b"unmap_page_range", fn_name=b"kprobe__unmap_page_range"
+        )
+        self.bpf.attach_kprobe(
+            event=b"__unmap_hugepage_range", fn_name=b"kprobe__unmap_hugepage_range"
+        )
+        self.bpf["unmap_range_output"].open_perf_buffer(
+            self._unmap_range_eh, page_cnt=64
+        )
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    self.bpf.attach_kprobe(event=b"unmap_page_range", fn_name=b"kprobe__unmap_page_range")
-    self.bpf.attach_kprobe(event=b"__unmap_hugepage_range", fn_name=b"kprobe__unmap_hugepage_range")
-    self.bpf["unmap_range_output"].open_perf_buffer(self._unmap_range_eh, page_cnt=64)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
-
-  def data(self) -> list[CollectionTable]:
-    return [
+    def data(self) -> list[CollectionTable]:
+        return [
             UnmapRangeDataTable.from_df_id(
                 pl.DataFrame(self.unmap_range_stat),
                 collection_id=self.collection_id,
             ),
         ]
 
-  def clear(self):
-    self.unmap_range_stat.clear()
+    def clear(self):
+        self.unmap_range_stat.clear()
 
-  def pop_data(self) -> list[CollectionTable]:
-    tables = self.data()
-    self.clear()
-    return tables
+    def pop_data(self) -> list[CollectionTable]:
+        tables = self.data()
+        self.clear()
+        return tables
 
-  def _unmap_range_eh(self, cpu, unmap_range_struct, size):
-      event = self.bpf["unmap_range_output"].event(unmap_range_struct)
-      self.unmap_range_stat.append(
-        UnmapRangeStat(
-          tgid=event.tgid,
-          ts_ns=event.ts_ns,
-          start=event.start,
-          end=event.end,
-          is_huge=False if event.huge == 0 else True,
+    def _unmap_range_eh(self, cpu, unmap_range_struct, size):
+        event = self.bpf["unmap_range_output"].event(unmap_range_struct)
+        self.unmap_range_stat.append(
+            UnmapRangeStat(
+                tgid=event.tgid,
+                ts_ns=event.ts_ns,
+                start=event.start,
+                end=event.end,
+                is_huge=False if event.huge == 0 else True,
+            )
         )
-      )

--- a/python/kernmlops/data_collection/bpf_instrumentation/zswap_runtime_hook.py
+++ b/python/kernmlops/data_collection/bpf_instrumentation/zswap_runtime_hook.py
@@ -10,89 +10,105 @@ from data_schema.generic_table import ZswapRuntimeDataTable
 
 @dataclass(frozen=True)
 class ZswapRuntimeStat:
-  pid: int
-  tgid: int
-  start_ts: int
-  end_ts: int
-  name: str
+    pid: int
+    tgid: int
+    start_ts: int
+    end_ts: int
+    name: str
+
 
 class ZswapRuntimeBPFHook(BPFProgram):
+    @classmethod
+    def name(cls) -> str:
+        return "zswap_runtime"
 
-  @classmethod
-  def name(cls) -> str:
-    return "zswap_runtime"
+    def __init__(self):
+        self.bpf_text = open(
+            Path(__file__).parent / "bpf/zswap_runtime.bpf.c", "r"
+        ).read()
+        self.trace_process = list[ZswapRuntimeStat]()
 
-  def __init__(self):
-    self.bpf_text = open(Path(__file__).parent / "bpf/zswap_runtime.bpf.c", "r").read()
-    self.trace_process = list[ZswapRuntimeStat]()
+    def load(self, collection_id: str):
+        self.collection_id = collection_id
+        self.bpf = BPF(text=self.bpf_text)
+        self.bpf.attach_kprobe(event=b"zswap_store", fn_name=b"trace_zswap_store_entry")
+        self.bpf.attach_kretprobe(
+            event=b"zswap_store", fn_name=b"trace_zswap_store_return"
+        )
+        self.bpf.attach_kprobe(event=b"zswap_load", fn_name=b"trace_zswap_load_entry")
+        self.bpf.attach_kretprobe(
+            event=b"zswap_load", fn_name=b"trace_zswap_load_return"
+        )
+        self.bpf.attach_kprobe(
+            event=b"zswap_invalidate", fn_name=b"trace_zswap_invalidate_entry"
+        )
+        self.bpf.attach_kretprobe(
+            event=b"zswap_invalidate", fn_name=b"trace_zswap_invalidate_return"
+        )
+        self.bpf["zswap_store_events"].open_perf_buffer(
+            self._zswap_store_eh, page_cnt=128
+        )
+        self.bpf["zswap_load_events"].open_perf_buffer(
+            self._zswap_load_eh, page_cnt=128
+        )
+        self.bpf["zswap_invalidate_events"].open_perf_buffer(
+            self._zswap_invalidate_eh, page_cnt=128
+        )
 
-  def load(self, collection_id: str):
-    self.collection_id = collection_id
-    self.bpf = BPF(text = self.bpf_text)
-    self.bpf.attach_kprobe(event=b"zswap_store", fn_name=b"trace_zswap_store_entry")
-    self.bpf.attach_kretprobe(event=b"zswap_store", fn_name=b"trace_zswap_store_return")
-    self.bpf.attach_kprobe(event=b"zswap_load", fn_name=b"trace_zswap_load_entry")
-    self.bpf.attach_kretprobe(event=b"zswap_load", fn_name=b"trace_zswap_load_return")
-    self.bpf.attach_kprobe(event=b"zswap_invalidate", fn_name=b"trace_zswap_invalidate_entry")
-    self.bpf.attach_kretprobe(event=b"zswap_invalidate", fn_name=b"trace_zswap_invalidate_return")
-    self.bpf["zswap_store_events"].open_perf_buffer(self._zswap_store_eh, page_cnt=128)
-    self.bpf["zswap_load_events"].open_perf_buffer(self._zswap_load_eh, page_cnt=128)
-    self.bpf["zswap_invalidate_events"].open_perf_buffer(self._zswap_invalidate_eh, page_cnt=128)
+    def poll(self):
+        self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
 
-  def poll(self):
-    self.bpf.perf_buffer_poll(timeout=POLL_TIMEOUT_MS)
+    def close(self):
+        self.bpf.cleanup()
 
-  def close(self):
-    self.bpf.cleanup()
-
-  def data(self) -> list[CollectionTable]:
-    return [
+    def data(self) -> list[CollectionTable]:
+        return [
             ZswapRuntimeDataTable.from_df_id(
                 pl.DataFrame(self.trace_process),
                 collection_id=self.collection_id,
             ),
         ]
 
-  def clear(self):
-    self.trace_process.clear()
+    def clear(self):
+        self.trace_process.clear()
 
-  def pop_data(self) -> list[CollectionTable]:
-    tables = self.data()
-    self.clear()
-    return tables
+    def pop_data(self) -> list[CollectionTable]:
+        tables = self.data()
+        self.clear()
+        return tables
 
-  def _zswap_store_eh(self, cpu, start_data, size):
-      event = self.bpf["zswap_store_events"].event(start_data)
-      self.trace_process.append(
-        ZswapRuntimeStat(
-          pid=event.pid,
-          tgid=event.tgid,
-          start_ts=event.start_ts,
-          end_ts=event.end_ts,
-          name="zswap_store"
+    def _zswap_store_eh(self, cpu, start_data, size):
+        event = self.bpf["zswap_store_events"].event(start_data)
+        self.trace_process.append(
+            ZswapRuntimeStat(
+                pid=event.pid,
+                tgid=event.tgid,
+                start_ts=event.start_ts,
+                end_ts=event.end_ts,
+                name="zswap_store",
+            )
         )
-      )
 
-  def _zswap_load_eh(self, cpu, start_data, size):
-      event = self.bpf["zswap_load_events"].event(start_data)
-      self.trace_process.append(
-        ZswapRuntimeStat(
-          pid=event.pid,
-          tgid=event.tgid,
-          start_ts=event.start_ts,
-          end_ts=event.end_ts,
-          name="zswap_load"
+    def _zswap_load_eh(self, cpu, start_data, size):
+        event = self.bpf["zswap_load_events"].event(start_data)
+        self.trace_process.append(
+            ZswapRuntimeStat(
+                pid=event.pid,
+                tgid=event.tgid,
+                start_ts=event.start_ts,
+                end_ts=event.end_ts,
+                name="zswap_load",
+            )
         )
-      )
 
-  def _zswap_invalidate_eh(self, cpu, start_data, size):
-      event = self.bpf["zswap_invalidate_events"].event(start_data)
-      self.trace_process.append(
-        ZswapRuntimeStat(
-          pid=event.pid,
-          tgid=event.tgid,
-          start_ts=event.start_ts,
-          end_ts=event.end_ts,
-          name="zswap_invalidate"
+    def _zswap_invalidate_eh(self, cpu, start_data, size):
+        event = self.bpf["zswap_invalidate_events"].event(start_data)
+        self.trace_process.append(
+            ZswapRuntimeStat(
+                pid=event.pid,
+                tgid=event.tgid,
+                start_ts=event.start_ts,
+                end_ts=event.end_ts,
+                name="zswap_invalidate",
+            )
         )
-      )

--- a/python/kernmlops/data_collection/system_info.py
+++ b/python/kernmlops/data_collection/system_info.py
@@ -27,7 +27,7 @@ class MachineSoftwareConfiguration:
     transparent_hugepages: str
     huge_pages: int
     huge_page_size_bytes: int
-    quanta_length: int # TODO(Patrick): add this
+    quanta_length: int  # TODO(Patrick): add this
     is_vm: bool = False
 
 
@@ -43,7 +43,7 @@ class MachineHardwareCacheConfiguration:
 
 @dataclass(frozen=True)
 class DiskPartitions:
-    device_id: int # (major << 20) | minor
+    device_id: int  # (major << 20) | minor
     name: str
     mount_point: str
     filesystem: str

--- a/python/kernmlops/data_import/__init__.py
+++ b/python/kernmlops/data_import/__init__.py
@@ -3,16 +3,20 @@ from pathlib import Path
 import polars as pl
 
 
-def read_parquet_dir(data_dir: Path | str, *, benchmark_name: str | None = None) -> dict[str, pl.DataFrame]:
+def read_parquet_dir(
+    data_dir: Path | str, *, benchmark_name: str | None = None
+) -> dict[str, pl.DataFrame]:
     if isinstance(data_dir, str):
         data_dir = Path(data_dir)
     kernmlops_dfs = dict[str, pl.DataFrame]()
     dataframe_dirs = [x for x in data_dir.iterdir() if x.is_dir()]
     for dataframe_dir in dataframe_dirs:
         dfs = [
-          pl.read_parquet(x) for x in dataframe_dir.iterdir()
-          if x.is_file() and x.suffix == ".parquet" and
-          (benchmark_name is None or x.suffixes[-2] == f".{benchmark_name}")
+            pl.read_parquet(x)
+            for x in dataframe_dir.iterdir()
+            if x.is_file()
+            and x.suffix == ".parquet"
+            and (benchmark_name is None or x.suffixes[-2] == f".{benchmark_name}")
         ]
         kernmlops_dfs[dataframe_dir.name] = pl.concat(dfs, how="diagonal_relaxed")
     return kernmlops_dfs

--- a/python/kernmlops/data_schema/__init__.py
+++ b/python/kernmlops/data_schema/__init__.py
@@ -35,9 +35,13 @@ table_types: list[type[CollectionTable]] = [
     CollapseHugePageDataTable,
 ] + list(perf.perf_table_types.values())
 
-def demote(user_id: int | None = None, group_id: int | None = None) -> Callable[[], None]:
+
+def demote(
+    user_id: int | None = None, group_id: int | None = None
+) -> Callable[[], None]:
     def no_op():
         pass
+
     if user_id is None:
         # if the user id is unspecified and the account is not privileged do nothing
         if os.getuid() >= 1000:
@@ -52,7 +56,9 @@ def demote(user_id: int | None = None, group_id: int | None = None) -> Callable[
     def do_demote():
         os.setgid(group_id)
         os.setuid(user_id)
+
     return do_demote
+
 
 def get_user_group_ids() -> tuple[int, int]:
     curr = os.getuid()
@@ -66,7 +72,6 @@ def get_user_group_ids() -> tuple[int, int]:
     group_id = int(os.environ.get("GID", user_id))
 
     return (user_id, group_id)
-
 
 
 __all__ = [

--- a/python/kernmlops/data_schema/block_io.py
+++ b/python/kernmlops/data_schema/block_io.py
@@ -1,4 +1,3 @@
-
 import polars as pl
 from data_schema.schema import (
     UPTIME_TIMESTAMP,
@@ -16,10 +15,10 @@ req_opf = {
     5: "SecureErase",
     6: "ZoneReset",
     7: "WriteSame",
-    9: "WriteZeros"
+    9: "WriteZeros",
 }
 REQ_OP_BITS = 8
-REQ_OP_MASK = ((1 << REQ_OP_BITS) - 1)
+REQ_OP_MASK = (1 << REQ_OP_BITS) - 1
 REQ_SYNC = 1 << (REQ_OP_BITS + 3)
 REQ_META = 1 << (REQ_OP_BITS + 4)
 REQ_PRIO = 1 << (REQ_OP_BITS + 5)
@@ -29,6 +28,8 @@ REQ_FUA = 1 << (REQ_OP_BITS + 9)
 REQ_RAHEAD = 1 << (REQ_OP_BITS + 11)
 REQ_BACKGROUND = 1 << (REQ_OP_BITS + 12)
 REQ_NOWAIT = 1 << (REQ_OP_BITS + 13)
+
+
 def flags_print(flags: int):
     desc = ""
     # operation
@@ -59,25 +60,26 @@ def flags_print(flags: int):
 
 
 class BlockIOQueueTable(CollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "block_io_queue_length"
 
     @classmethod
     def schema(cls) -> pl.Schema:
-        return pl.Schema({
-            "cpu": pl.Int64(),
-            "device": pl.Int64(),
-            "sector": pl.Int64(),
-            "segments": pl.Int64(),
-            "block_io_bytes": pl.Int64(),
-            UPTIME_TIMESTAMP: pl.Int64(),
-            "block_io_flags": pl.Int64(),
-            "queue_length_segment_ios": pl.Int64(),
-            "queue_length_4k_ios": pl.Int64(),
-            "collection_id": pl.String(),
-        })
+        return pl.Schema(
+            {
+                "cpu": pl.Int64(),
+                "device": pl.Int64(),
+                "sector": pl.Int64(),
+                "segments": pl.Int64(),
+                "block_io_bytes": pl.Int64(),
+                UPTIME_TIMESTAMP: pl.Int64(),
+                "block_io_flags": pl.Int64(),
+                "queue_length_segment_ios": pl.Int64(),
+                "queue_length_4k_ios": pl.Int64(),
+                "collection_id": pl.String(),
+            }
+        )
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "BlockIOQueueTable":
@@ -98,25 +100,26 @@ class BlockIOQueueTable(CollectionTable):
 
 
 class BlockIOLatencyTable(CollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "block_io_latency"
 
     @classmethod
     def schema(cls) -> pl.Schema:
-        return pl.Schema({
-            "cpu": pl.Int64(),
-            "device": pl.Int64(),
-            "sector": pl.Int64(),
-            "segments": pl.Int64(),
-            "block_io_bytes": pl.Int64(),
-            UPTIME_TIMESTAMP: pl.Int64(),
-            "block_latency_us": pl.Int64(),
-            "block_io_latency_us": pl.Int64(),
-            "block_io_flags": pl.Int64(),
-            "collection_id": pl.String(),
-        })
+        return pl.Schema(
+            {
+                "cpu": pl.Int64(),
+                "device": pl.Int64(),
+                "sector": pl.Int64(),
+                "segments": pl.Int64(),
+                "block_io_bytes": pl.Int64(),
+                UPTIME_TIMESTAMP: pl.Int64(),
+                "block_latency_us": pl.Int64(),
+                "block_io_latency_us": pl.Int64(),
+                "block_io_flags": pl.Int64(),
+                "collection_id": pl.String(),
+            }
+        )
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "BlockIOLatencyTable":
@@ -145,44 +148,56 @@ class BlockIOTable(CollectionTable):
 
     @classmethod
     def schema(cls) -> pl.Schema:
-        return pl.Schema({
-            "cpu": pl.Int64(),
-            "device": pl.Int64(),
-            "sector": pl.Int64(),
-            "segments": pl.Int64(),
-            "block_io_bytes": pl.Int64(),
-            UPTIME_TIMESTAMP: pl.Int64(),
-            "finish_ts_uptime_us": pl.Int64(),
-            "block_latency_us": pl.Int64(),
-            "block_io_latency_us": pl.Int64(),
-            "measured_latency_us": pl.Int64(),
-            "block_io_flags": pl.Int64(),
-            "block_io_flags_string": pl.String(),
-            "queue_length_segment_ios": pl.Int64(),
-            "queue_length_4k_ios": pl.Int64(),
-            "collection_id": pl.String(),
-        })
+        return pl.Schema(
+            {
+                "cpu": pl.Int64(),
+                "device": pl.Int64(),
+                "sector": pl.Int64(),
+                "segments": pl.Int64(),
+                "block_io_bytes": pl.Int64(),
+                UPTIME_TIMESTAMP: pl.Int64(),
+                "finish_ts_uptime_us": pl.Int64(),
+                "block_latency_us": pl.Int64(),
+                "block_io_latency_us": pl.Int64(),
+                "measured_latency_us": pl.Int64(),
+                "block_io_flags": pl.Int64(),
+                "block_io_flags_string": pl.String(),
+                "queue_length_segment_ios": pl.Int64(),
+                "queue_length_4k_ios": pl.Int64(),
+                "collection_id": pl.String(),
+            }
+        )
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "BlockIOTable":
         return BlockIOTable(table=table.cast(cls.schema(), strict=True))  # pyright: ignore [reportArgumentType]
 
     @classmethod
-    def from_tables(cls, queue_table: BlockIOQueueTable, latency_table: BlockIOLatencyTable) -> "BlockIOTable":
+    def from_tables(
+        cls, queue_table: BlockIOQueueTable, latency_table: BlockIOLatencyTable
+    ) -> "BlockIOTable":
         queue_df = queue_table.filtered_table()
-        latency_df = latency_table.filtered_table().select([
-            "device",
-            "sector",
-            "segments",
-            "block_io_bytes",
-            UPTIME_TIMESTAMP,
-            "block_latency_us",
-            "block_io_latency_us",
-            "block_io_flags",
-            "collection_id",
-        ]).rename({
-            UPTIME_TIMESTAMP: "finish_ts_uptime_us",
-        })
+        latency_df = (
+            latency_table.filtered_table()
+            .select(
+                [
+                    "device",
+                    "sector",
+                    "segments",
+                    "block_io_bytes",
+                    UPTIME_TIMESTAMP,
+                    "block_latency_us",
+                    "block_io_latency_us",
+                    "block_io_flags",
+                    "collection_id",
+                ]
+            )
+            .rename(
+                {
+                    UPTIME_TIMESTAMP: "finish_ts_uptime_us",
+                }
+            )
+        )
         block_df = queue_df.join(
             latency_df,
             on=[
@@ -195,23 +210,37 @@ class BlockIOTable(CollectionTable):
             ],
             how="inner",
         ).filter(
-            ((pl.col("finish_ts_uptime_us") - pl.col(UPTIME_TIMESTAMP)) > 0) &
-            ((pl.col("finish_ts_uptime_us") - pl.col(UPTIME_TIMESTAMP)) < pl.col("block_latency_us"))
+            ((pl.col("finish_ts_uptime_us") - pl.col(UPTIME_TIMESTAMP)) > 0)
+            & (
+                (pl.col("finish_ts_uptime_us") - pl.col(UPTIME_TIMESTAMP))
+                < pl.col("block_latency_us")
+            )
         )
-        block_df = block_df.unique([
-            "cpu",
-            "device",
-            "sector",
-            "segments",
-            "block_io_bytes",
-            UPTIME_TIMESTAMP,
-            "block_io_flags",
-        ]).with_columns(
-            (pl.col("finish_ts_uptime_us") - pl.col(UPTIME_TIMESTAMP)).alias("measured_latency_us"),
-            pl.col("block_io_flags").map_elements(
-                flags_print, return_dtype=pl.String,
-            ).alias("block_io_flags_string"),
-        ).sort(UPTIME_TIMESTAMP, descending=False)
+        block_df = (
+            block_df.unique(
+                [
+                    "cpu",
+                    "device",
+                    "sector",
+                    "segments",
+                    "block_io_bytes",
+                    UPTIME_TIMESTAMP,
+                    "block_io_flags",
+                ]
+            )
+            .with_columns(
+                (pl.col("finish_ts_uptime_us") - pl.col(UPTIME_TIMESTAMP)).alias(
+                    "measured_latency_us"
+                ),
+                pl.col("block_io_flags")
+                .map_elements(
+                    flags_print,
+                    return_dtype=pl.String,
+                )
+                .alias("block_io_flags_string"),
+            )
+            .sort(UPTIME_TIMESTAMP, descending=False)
+        )
         return cls.from_df(block_df)
 
     def __init__(self, table: pl.DataFrame):
@@ -229,41 +258,52 @@ class BlockIOTable(CollectionTable):
 
     def summary_df(self) -> pl.DataFrame:
         """Returns a summary of all IO done per device."""
-        return self.filtered_table().group_by("device").agg([
-            pl.len().alias("disk_io_count"),
-
-            pl.sum("segments").alias("total_segments"),
-            (pl.sum("block_io_bytes") / 1024.0 / 1024.0).alias("total_block_io_mb"),
-            pl.max("segments").alias("max_segments"),
-            pl.max("block_io_bytes").alias("max_block_io_bytes"),
-
-            (pl.sum("block_latency_us") / 1000.0).alias("total_block_latency_ms"),
-            (pl.sum("block_io_latency_us") / 1000.0).alias("total_io_block_latency_ms"),
-            (pl.sum("measured_latency_us") / 1000.0).alias("total_measured_latency_ms"),
-            pl.mean("block_latency_us").alias("avg_block_latency_us"),
-            pl.mean("block_io_latency_us").alias("avg_io_block_latency_us"),
-            pl.mean("measured_latency_us").alias("avg_measured_latency_us"),
-            pl.max("block_latency_us").alias("max_block_latency_us"),
-            pl.max("block_io_latency_us").alias("max_io_block_latency_us"),
-            pl.max("measured_latency_us").alias("max_measured_latency_us"),
-
-            pl.mean("queue_length_segment_ios").alias("avg_queue_length_segment_ios"),
-            pl.mean("queue_length_4k_ios").alias("avg_queue_length_4k_ios"),
-            pl.max("queue_length_segment_ios").alias("max_queue_length_segment_ios"),
-            pl.max("queue_length_4k_ios").alias("max_queue_length_4k_ios"),
-        ])
+        return (
+            self.filtered_table()
+            .group_by("device")
+            .agg(
+                [
+                    pl.len().alias("disk_io_count"),
+                    pl.sum("segments").alias("total_segments"),
+                    (pl.sum("block_io_bytes") / 1024.0 / 1024.0).alias(
+                        "total_block_io_mb"
+                    ),
+                    pl.max("segments").alias("max_segments"),
+                    pl.max("block_io_bytes").alias("max_block_io_bytes"),
+                    (pl.sum("block_latency_us") / 1000.0).alias(
+                        "total_block_latency_ms"
+                    ),
+                    (pl.sum("block_io_latency_us") / 1000.0).alias(
+                        "total_io_block_latency_ms"
+                    ),
+                    (pl.sum("measured_latency_us") / 1000.0).alias(
+                        "total_measured_latency_ms"
+                    ),
+                    pl.mean("block_latency_us").alias("avg_block_latency_us"),
+                    pl.mean("block_io_latency_us").alias("avg_io_block_latency_us"),
+                    pl.mean("measured_latency_us").alias("avg_measured_latency_us"),
+                    pl.max("block_latency_us").alias("max_block_latency_us"),
+                    pl.max("block_io_latency_us").alias("max_io_block_latency_us"),
+                    pl.max("measured_latency_us").alias("max_measured_latency_us"),
+                    pl.mean("queue_length_segment_ios").alias(
+                        "avg_queue_length_segment_ios"
+                    ),
+                    pl.mean("queue_length_4k_ios").alias("avg_queue_length_4k_ios"),
+                    pl.max("queue_length_segment_ios").alias(
+                        "max_queue_length_segment_ios"
+                    ),
+                    pl.max("queue_length_4k_ios").alias("max_queue_length_4k_ios"),
+                ]
+            )
+        )
 
 
 class BlockQueueGraph(CollectionGraph):
-
     @classmethod
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         block_table = graph_engine.collection_data.get(BlockIOTable)
         if block_table is not None:
-            return BlockQueueGraph(
-                graph_engine=graph_engine,
-                block_table=block_table
-            )
+            return BlockQueueGraph(graph_engine=graph_engine, block_table=block_table)
         return None
 
     @classmethod
@@ -298,7 +338,9 @@ class BlockQueueGraph(CollectionGraph):
         for device, block_df_group in block_df_by_device:
             self.graph_engine.plot(
                 self.collection_data.normalize_uptime_sec(block_df_group),
-                (block_df_group.select("queue_length_segment_ios")).to_series().to_list(),
+                (block_df_group.select("queue_length_segment_ios"))
+                .to_series()
+                .to_list(),
                 label=f"Device {device[0]} Segment IOs",
             )
             self.graph_engine.plot(

--- a/python/kernmlops/data_schema/file_data.py
+++ b/python/kernmlops/data_schema/file_data.py
@@ -7,23 +7,24 @@ from data_schema.schema import (
 
 
 class FileDataTable(CollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "file_data"
 
     @classmethod
     def schema(cls) -> pl.Schema:
-        return pl.Schema({
-            "cpu": pl.Int64(),
-            "pid": pl.Int64(),
-            "tgid": pl.Int64(),
-            UPTIME_TIMESTAMP: pl.Int64(),
-            "file_inode": pl.Int64(),
-            "file_size_bytes": pl.Int64(),
-            "file_name": pl.String(),
-            "collection_id": pl.String(),
-        })
+        return pl.Schema(
+            {
+                "cpu": pl.Int64(),
+                "pid": pl.Int64(),
+                "tgid": pl.Int64(),
+                UPTIME_TIMESTAMP: pl.Int64(),
+                "file_inode": pl.Int64(),
+                "file_size_bytes": pl.Int64(),
+                "file_name": pl.String(),
+                "collection_id": pl.String(),
+            }
+        )
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "FileDataTable":
@@ -53,18 +54,22 @@ class FileDataTable(CollectionTable):
         file_data = self.get_file_data(filename)
         if len(file_data) == 0:
             return None
-        return file_data.sort(
-            UPTIME_TIMESTAMP, descending=False
-        ).head(n=1).select(
-            UPTIME_TIMESTAMP
-        ).to_series().to_list()[0]
+        return (
+            file_data.sort(UPTIME_TIMESTAMP, descending=False)
+            .head(n=1)
+            .select(UPTIME_TIMESTAMP)
+            .to_series()
+            .to_list()[0]
+        )
 
     def get_last_occurrence_us(self, filename: str) -> int | None:
         file_data = self.get_file_data(filename)
         if len(file_data) == 0:
             return None
-        return file_data.sort(
-            UPTIME_TIMESTAMP, descending=True
-        ).head(n=1).select(
-            UPTIME_TIMESTAMP
-        ).to_series().to_list()[0]
+        return (
+            file_data.sort(UPTIME_TIMESTAMP, descending=True)
+            .head(n=1)
+            .select(UPTIME_TIMESTAMP)
+            .to_series()
+            .to_list()[0]
+        )

--- a/python/kernmlops/data_schema/generic_table.py
+++ b/python/kernmlops/data_schema/generic_table.py
@@ -10,7 +10,7 @@ from typing_extensions import (
 
 class GenericTableMeta(_ProtocolMeta):
     def __new__(cls, name, bases, dct):
-        probe_name = dct.get('probe_name')
+        probe_name = dct.get("probe_name")
 
         def name_func(cls) -> str:
             return f"{probe_name}"
@@ -18,7 +18,7 @@ class GenericTableMeta(_ProtocolMeta):
         def schema(cls) -> pl.Schema:
             return pl.Schema()
 
-        def from_df(cls, table: pl.DataFrame) -> name: # pyright: ignore [reportInvalidTypeForm]
+        def from_df(cls, table: pl.DataFrame) -> name:  # pyright: ignore [reportInvalidTypeForm]
             return cls(table=table)
 
         def __init__(self, table: pl.DataFrame):
@@ -47,35 +47,46 @@ class GenericTableMeta(_ProtocolMeta):
         dct["by_pid"] = by_pid
         return super().__new__(cls, name, bases, dct)
 
+
 class ProcessMetadataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "process_metadata"
+
 
 class ProcessTraceDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "process_trace"
 
+
 class TraceMMRSSStatDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "mm_rss_stat"
+
 
 class ZswapRuntimeDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "zswap_runtime"
 
+
 class TraceMMKhugepagedScanPMDDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "trace_mm_khugepaged_scan_pmd"
+
 
 class CollapseHugePageDataTableRaw(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "collapse_huge_pages"
 
+
 class TraceMMCollapseHugePageDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "trace_mm_collapse_huge_page"
+
 
 class CBMMEagerDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "cbmm_eager"
 
+
 class CBMMPrezeroingDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "cbmm_prezero"
 
+
 class MadviseDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "madvise"
+
 
 class UnmapRangeDataTable(CollectionTable, metaclass=GenericTableMeta):
     probe_name = "unmap_range"

--- a/python/kernmlops/data_schema/huge_pages.py
+++ b/python/kernmlops/data_schema/huge_pages.py
@@ -22,26 +22,43 @@ class CollapseHugePageDataTable(CollectionTable):
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "CollapseHugePageDataTable":
-        return CollapseHugePageDataTable(table=table) #.cast(cls.schema(), strict=True))  # pyright: ignore [reportArgumentType]
+        return CollapseHugePageDataTable(
+            table=table
+        )  # .cast(cls.schema(), strict=True))  # pyright: ignore [reportArgumentType]
 
     @classmethod
-    def from_tables(cls, collapse_table: CollapseHugePageDataTableRaw, trace_mm_table: TraceMMCollapseHugePageDataTable) -> "CollapseHugePageDataTable":
-        collapse_df = collapse_table.filtered_table().sort("start_ts_ns", descending=False)
-        trace_mm_df = trace_mm_table.filtered_table().sort("start_ts_ns", descending=False)
-        if trace_mm_df.row(0, named=True)["start_ts_ns"] < collapse_df.row(0, named=True)["start_ts_ns"]:
+    def from_tables(
+        cls,
+        collapse_table: CollapseHugePageDataTableRaw,
+        trace_mm_table: TraceMMCollapseHugePageDataTable,
+    ) -> "CollapseHugePageDataTable":
+        collapse_df = collapse_table.filtered_table().sort(
+            "start_ts_ns", descending=False
+        )
+        trace_mm_df = trace_mm_table.filtered_table().sort(
+            "start_ts_ns", descending=False
+        )
+        if (
+            trace_mm_df.row(0, named=True)["start_ts_ns"]
+            < collapse_df.row(0, named=True)["start_ts_ns"]
+        ):
             collapse_df = collapse_df[1:]
         assert len(collapse_df) == len(trace_mm_df)
-        collapse_df = collapse_df.drop([
-            "end_ts_ns",
-        ])
-        trace_mm_df = trace_mm_df.drop([
-            "pid",
-            "tgid",
-            "start_ts_ns",
-            "end_ts_ns",
-            "mm",
-            "collection_id",
-        ])
+        collapse_df = collapse_df.drop(
+            [
+                "end_ts_ns",
+            ]
+        )
+        trace_mm_df = trace_mm_df.drop(
+            [
+                "pid",
+                "tgid",
+                "start_ts_ns",
+                "end_ts_ns",
+                "mm",
+                "collection_id",
+            ]
+        )
         return cls.from_df(pl.concat([collapse_df, trace_mm_df], how="horizontal"))
 
     def __init__(self, table: pl.DataFrame):

--- a/python/kernmlops/data_schema/memory_usage.py
+++ b/python/kernmlops/data_schema/memory_usage.py
@@ -8,41 +8,36 @@ from data_schema.schema import (
 
 
 class MemoryUsageTable(CollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "memory_usage"
 
     @classmethod
     def schema(cls) -> pl.Schema:
-        return pl.Schema({
-            UPTIME_TIMESTAMP: pl.Int64(),
-
-            "mem_total_bytes": pl.Int64(),
-            "mem_free_bytes": pl.Int64(),
-            "mem_available_bytes": pl.Int64(),
-            "buffers_bytes": pl.Int64(),
-            "cached_bytes": pl.Int64(),
-
-            "swap_total_bytes": pl.Int64(),
-            "swap_free_bytes": pl.Int64(),
-
-            # data waiting to be written back to disk
-            "dirty_bytes": pl.Int64(),
-            "writeback_bytes": pl.Int64(),
-
-            "anon_pages_total_bytes": pl.Int64(),
-            "anon_hugepages_total_bytes": pl.Int64(),
-            "mapped_total_bytes": pl.Int64(),
-            "shmem_total_bytes": pl.Int64(),
-
-            "hugepages_total": pl.Int64(),
-            "hugepages_free": pl.Int64(),
-            "hugepages_reserved": pl.Int64(),
-            "hugepage_size_bytes": pl.Int64(),
-
-            "hardware_corrupted_bytes": pl.Int64(),
-        })
+        return pl.Schema(
+            {
+                UPTIME_TIMESTAMP: pl.Int64(),
+                "mem_total_bytes": pl.Int64(),
+                "mem_free_bytes": pl.Int64(),
+                "mem_available_bytes": pl.Int64(),
+                "buffers_bytes": pl.Int64(),
+                "cached_bytes": pl.Int64(),
+                "swap_total_bytes": pl.Int64(),
+                "swap_free_bytes": pl.Int64(),
+                # data waiting to be written back to disk
+                "dirty_bytes": pl.Int64(),
+                "writeback_bytes": pl.Int64(),
+                "anon_pages_total_bytes": pl.Int64(),
+                "anon_hugepages_total_bytes": pl.Int64(),
+                "mapped_total_bytes": pl.Int64(),
+                "shmem_total_bytes": pl.Int64(),
+                "hugepages_total": pl.Int64(),
+                "hugepages_free": pl.Int64(),
+                "hugepages_reserved": pl.Int64(),
+                "hugepage_size_bytes": pl.Int64(),
+                "hardware_corrupted_bytes": pl.Int64(),
+            }
+        )
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "MemoryUsageTable":
@@ -63,14 +58,12 @@ class MemoryUsageTable(CollectionTable):
 
 
 class MemoryUsageGraph(CollectionGraph):
-
     @classmethod
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         memory_usage_table = graph_engine.collection_data.get(MemoryUsageTable)
         if memory_usage_table is not None:
             return MemoryUsageGraph(
-                graph_engine=graph_engine,
-                memory_usage_table=memory_usage_table
+                graph_engine=graph_engine, memory_usage_table=memory_usage_table
             )
         return None
 
@@ -115,7 +108,7 @@ class MemoryUsageGraph(CollectionGraph):
         for plot_line in self.plot_lines:
             self.graph_engine.plot(
                 self.collection_data.normalize_uptime_sec(memory_df),
-                (memory_df.select(plot_line) / (1_024.0)**3).to_series().to_list(),
+                (memory_df.select(plot_line) / (1_024.0) ** 3).to_series().to_list(),
                 label=plot_line.replace("bytes", "gb"),
                 y_axis=self.y_axis(),
             )

--- a/python/kernmlops/data_schema/perf/__init__.py
+++ b/python/kernmlops/data_schema/perf/__init__.py
@@ -19,7 +19,7 @@ perf_table_types: Mapping[str, type[PerfCollectionTable]] = {
 }
 
 __all__ = [
-  "perf_table_types",
-  "CustomHWEventID",
-  "PerfCollectionTable",
+    "perf_table_types",
+    "CustomHWEventID",
+    "PerfCollectionTable",
 ]

--- a/python/kernmlops/data_schema/perf/tlb_perf.py
+++ b/python/kernmlops/data_schema/perf/tlb_perf.py
@@ -15,7 +15,6 @@ from data_schema.schema import (
 
 
 class DTLBPerfTable(PerfCollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "dtlb_misses"
@@ -26,11 +25,11 @@ class DTLBPerfTable(PerfCollectionTable):
 
     @classmethod
     def ev_config(cls) -> int:
-      return PerfHWCacheConfig.config(
-        cache=PerfHWCacheConfig.Cache.PERF_COUNT_HW_CACHE_DTLB,
-        op=PerfHWCacheConfig.Op.PERF_COUNT_HW_CACHE_OP_READ,
-        result=PerfHWCacheConfig.Result.PERF_COUNT_HW_CACHE_RESULT_MISS,
-      )
+        return PerfHWCacheConfig.config(
+            cache=PerfHWCacheConfig.Cache.PERF_COUNT_HW_CACHE_DTLB,
+            op=PerfHWCacheConfig.Op.PERF_COUNT_HW_CACHE_OP_READ,
+            result=PerfHWCacheConfig.Result.PERF_COUNT_HW_CACHE_RESULT_MISS,
+        )
 
     @classmethod
     def hw_ids(cls) -> list[CustomHWEventID]:
@@ -75,10 +74,7 @@ class DTLBRateGraph(RatePerfGraph):
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         perf_table = graph_engine.collection_data.get(cls.perf_table_type())
         if perf_table is not None:
-            return DTLBRateGraph(
-                graph_engine=graph_engine,
-                perf_table=perf_table
-            )
+            return DTLBRateGraph(graph_engine=graph_engine, perf_table=perf_table)
         return None
 
 
@@ -95,15 +91,11 @@ class DTLBCumulativeGraph(CumulativePerfGraph):
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         perf_table = graph_engine.collection_data.get(cls.perf_table_type())
         if perf_table is not None:
-            return DTLBCumulativeGraph(
-                graph_engine=graph_engine,
-                perf_table=perf_table
-            )
+            return DTLBCumulativeGraph(graph_engine=graph_engine, perf_table=perf_table)
         return None
 
 
 class ITLBPerfTable(PerfCollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "itlb_misses"
@@ -114,11 +106,11 @@ class ITLBPerfTable(PerfCollectionTable):
 
     @classmethod
     def ev_config(cls) -> int:
-      return PerfHWCacheConfig.config(
-        cache=PerfHWCacheConfig.Cache.PERF_COUNT_HW_CACHE_ITLB,
-        op=PerfHWCacheConfig.Op.PERF_COUNT_HW_CACHE_OP_READ,
-        result=PerfHWCacheConfig.Result.PERF_COUNT_HW_CACHE_RESULT_MISS,
-      )
+        return PerfHWCacheConfig.config(
+            cache=PerfHWCacheConfig.Cache.PERF_COUNT_HW_CACHE_ITLB,
+            op=PerfHWCacheConfig.Op.PERF_COUNT_HW_CACHE_OP_READ,
+            result=PerfHWCacheConfig.Result.PERF_COUNT_HW_CACHE_RESULT_MISS,
+        )
 
     @classmethod
     def hw_ids(cls) -> list[CustomHWEventID]:
@@ -163,10 +155,7 @@ class ITLBRateGraph(RatePerfGraph):
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         perf_table = graph_engine.collection_data.get(cls.perf_table_type())
         if perf_table is not None:
-            return ITLBRateGraph(
-                graph_engine=graph_engine,
-                perf_table=perf_table
-            )
+            return ITLBRateGraph(graph_engine=graph_engine, perf_table=perf_table)
         return None
 
 
@@ -183,15 +172,11 @@ class ITLBCumulativeGraph(CumulativePerfGraph):
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         perf_table = graph_engine.collection_data.get(cls.perf_table_type())
         if perf_table is not None:
-            return ITLBCumulativeGraph(
-                graph_engine=graph_engine,
-                perf_table=perf_table
-            )
+            return ITLBCumulativeGraph(graph_engine=graph_engine, perf_table=perf_table)
         return None
 
 
 class TLBFlushPerfTable(PerfCollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "tlb_flushes"
@@ -250,10 +235,7 @@ class TLBFlushRateGraph(RatePerfGraph):
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         perf_table = graph_engine.collection_data.get(cls.perf_table_type())
         if perf_table is not None:
-            return TLBFlushRateGraph(
-                graph_engine=graph_engine,
-                perf_table=perf_table
-            )
+            return TLBFlushRateGraph(graph_engine=graph_engine, perf_table=perf_table)
         return None
 
 
@@ -271,14 +253,12 @@ class TLBFlushCumulativeGraph(CumulativePerfGraph):
         perf_table = graph_engine.collection_data.get(cls.perf_table_type())
         if perf_table is not None:
             return TLBFlushCumulativeGraph(
-                graph_engine=graph_engine,
-                perf_table=perf_table
+                graph_engine=graph_engine, perf_table=perf_table
             )
         return None
 
 
 class DTLBWalkDurationPerfTable(PerfCollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "dtlb_walk_duration"

--- a/python/kernmlops/data_schema/quanta_runtime.py
+++ b/python/kernmlops/data_schema/quanta_runtime.py
@@ -12,21 +12,22 @@ from data_schema.schema import (
 
 
 class QuantaRuntimeTable(CollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "quanta_runtime"
 
     @classmethod
     def schema(cls) -> pl.Schema:
-        return pl.Schema({
-            "cpu": pl.Int64(),
-            "pid": pl.Int64(),
-            "tgid": pl.Int64(),
-            UPTIME_TIMESTAMP: pl.Int64(),
-            "quanta_run_length_us": pl.Int64(),
-            "collection_id": pl.String(),
-        })
+        return pl.Schema(
+            {
+                "cpu": pl.Int64(),
+                "pid": pl.Int64(),
+                "tgid": pl.Int64(),
+                UPTIME_TIMESTAMP: pl.Int64(),
+                "quanta_run_length_us": pl.Int64(),
+                "collection_id": pl.String(),
+            }
+        )
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "QuantaRuntimeTable":
@@ -44,12 +45,12 @@ class QuantaRuntimeTable(CollectionTable):
         # these are probably due to hardware threads not running
         initial_datapoints = len(self.table)
         max_run_length = 60_000
-        quanta_df = self.table.filter(
-          pl.col("quanta_run_length_us") < max_run_length
-        )
+        quanta_df = self.table.filter(pl.col("quanta_run_length_us") < max_run_length)
         datapoints_removed = initial_datapoints - len(quanta_df)
         # TODO(Patrick): use logging
-        print(f"Filtered out {datapoints_removed} datapoints with max run length {max_run_length}us")
+        print(
+            f"Filtered out {datapoints_removed} datapoints with max run length {max_run_length}us"
+        )
         return quanta_df
 
     def graphs(self) -> list[type[CollectionGraph]]:
@@ -57,49 +58,60 @@ class QuantaRuntimeTable(CollectionTable):
 
     def total_runtime_us(self) -> int:
         """Returns the total amount of runtime recorded across all cpus."""
-        return self.filtered_table().select(
-            "quanta_run_length_us"
-        ).sum()["quanta_run_length_us"].to_list()[0]
+        return (
+            self.filtered_table()
+            .select("quanta_run_length_us")
+            .sum()["quanta_run_length_us"]
+            .to_list()[0]
+        )
 
     def per_cpu_total_runtime_sec(self) -> pl.DataFrame:
         """Returns the total amount of runtime recorded per cpu."""
-        return self.filtered_table().group_by(
-            "cpu"
-        ).agg(
-            pl.sum("quanta_run_length_us")
-        ).select([
-            "cpu",
-            (pl.col("quanta_run_length_us") / 1_000_000.0).alias("cpu_total_runtime_sec"),
-        ]).sort("cpu_total_runtime_sec")
+        return (
+            self.filtered_table()
+            .group_by("cpu")
+            .agg(pl.sum("quanta_run_length_us"))
+            .select(
+                [
+                    "cpu",
+                    (pl.col("quanta_run_length_us") / 1_000_000.0).alias(
+                        "cpu_total_runtime_sec"
+                    ),
+                ]
+            )
+            .sort("cpu_total_runtime_sec")
+        )
 
     def top_k_runtime(self, k: int) -> pl.DataFrame:
         """Returns the pids and execution time of the k processes with the most execution time."""
         # in kernel space thread id and pid meanings are swapped
-        return self.filtered_table().select(
-            [pl.col("tgid").alias("pid"), "quanta_run_length_us"]
-        ).group_by(
-            "pid"
-        ).sum().sort(
-            "quanta_run_length_us", descending=True
-        ).limit(k)
+        return (
+            self.filtered_table()
+            .select([pl.col("tgid").alias("pid"), "quanta_run_length_us"])
+            .group_by("pid")
+            .sum()
+            .sort("quanta_run_length_us", descending=True)
+            .limit(k)
+        )
 
 
 class QuantaQueuedTable(CollectionTable):
-
     @classmethod
     def name(cls) -> str:
         return "quanta_queued_time"
 
     @classmethod
     def schema(cls) -> pl.Schema:
-        return pl.Schema({
-            "cpu": pl.Int64(),
-            "pid": pl.Int64(),
-            "tgid": pl.Int64(),
-            UPTIME_TIMESTAMP: pl.Int64(),
-            "quanta_queued_time_us": pl.Int64(),
-            "collection_id": pl.String(),
-        })
+        return pl.Schema(
+            {
+                "cpu": pl.Int64(),
+                "pid": pl.Int64(),
+                "tgid": pl.Int64(),
+                UPTIME_TIMESTAMP: pl.Int64(),
+                "quanta_queued_time_us": pl.Int64(),
+                "collection_id": pl.String(),
+            }
+        )
 
     @classmethod
     def from_df(cls, table: pl.DataFrame) -> "QuantaQueuedTable":
@@ -117,11 +129,13 @@ class QuantaQueuedTable(CollectionTable):
         initial_datapoints = len(self.table)
         max_queue_time_us = 1_000_000
         quanta_df = self.table.filter(
-          pl.col("quanta_queued_time_us") < max_queue_time_us
+            pl.col("quanta_queued_time_us") < max_queue_time_us
         )
         datapoints_removed = initial_datapoints - len(quanta_df)
         # TODO(Patrick): use logging
-        print(f"Filtered out {datapoints_removed} datapoints with max queue time {max_queue_time_us}us")
+        print(
+            f"Filtered out {datapoints_removed} datapoints with max queue time {max_queue_time_us}us"
+        )
         return quanta_df
 
     def graphs(self) -> list[type[CollectionGraph]]:
@@ -129,42 +143,50 @@ class QuantaQueuedTable(CollectionTable):
 
     def total_queued_time_us(self) -> int:
         """Returns the total amount of queued time recorded across all cpus."""
-        return self.filtered_table().select(
-            "quanta_queued_time_us"
-        ).sum()["quanta_queued_time_us"].to_list()[0]
+        return (
+            self.filtered_table()
+            .select("quanta_queued_time_us")
+            .sum()["quanta_queued_time_us"]
+            .to_list()[0]
+        )
 
     def per_cpu_total_runtime_sec(self) -> pl.DataFrame:
         """Returns the total amount of Queued time recorded per cpu."""
-        return self.filtered_table().group_by(
-            "cpu"
-        ).agg(
-            pl.sum("quanta_queued_time_us")
-        ).select([
-            "cpu",
-            (pl.col("quanta_queued_time_us") / 1_000_000.0).alias("cpu_total_queued_time_sec"),
-        ]).sort("cpu_total_queued_time_sec")
+        return (
+            self.filtered_table()
+            .group_by("cpu")
+            .agg(pl.sum("quanta_queued_time_us"))
+            .select(
+                [
+                    "cpu",
+                    (pl.col("quanta_queued_time_us") / 1_000_000.0).alias(
+                        "cpu_total_queued_time_sec"
+                    ),
+                ]
+            )
+            .sort("cpu_total_queued_time_sec")
+        )
 
     def top_k_queued_time(self, k: int) -> pl.DataFrame:
         """Returns the pids and execution time of the k processes with the most queued time."""
         # in kernel space thread id and pid meanings are swapped
-        return self.filtered_table().select(
-            [pl.col("tgid").alias("pid"), "quanta_queued_time_us"]
-        ).group_by(
-            "pid"
-        ).sum().sort(
-            "quanta_queued_time_us", descending=True
-        ).limit(k)
+        return (
+            self.filtered_table()
+            .select([pl.col("tgid").alias("pid"), "quanta_queued_time_us"])
+            .group_by("pid")
+            .sum()
+            .sort("quanta_queued_time_us", descending=True)
+            .limit(k)
+        )
 
 
 class QuantaRuntimeGraph(CollectionGraph):
-
     @classmethod
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         quanta_table = graph_engine.collection_data.get(QuantaRuntimeTable)
         if quanta_table is not None:
             return QuantaRuntimeGraph(
-                graph_engine=graph_engine,
-                quanta_table=quanta_table
+                graph_engine=graph_engine, quanta_table=quanta_table
             )
         return None
 
@@ -198,7 +220,9 @@ class QuantaRuntimeGraph(CollectionGraph):
         for cpu, quanta_df_group in quanta_df_by_cpu:
             self.graph_engine.scatter(
                 self.collection_data.normalize_uptime_sec(quanta_df_group),
-                (quanta_df_group.select("quanta_run_length_us") / 1_000.0).to_series().to_list(),
+                (quanta_df_group.select("quanta_run_length_us") / 1_000.0)
+                .to_series()
+                .to_list(),
                 label=f"CPU {cpu[0]}",
             )
 
@@ -210,23 +234,32 @@ class QuantaRuntimeGraph(CollectionGraph):
         collector_pid = self.collection_data.pid
         top_k = quanta_table.top_k_runtime(k=3)
         print(top_k)
-        pid_labels: Mapping[int, str] = self._get_pid_labels(top_k["pid"].to_list() + [collector_pid], collector_pid)
+        pid_labels: Mapping[int, str] = self._get_pid_labels(
+            top_k["pid"].to_list() + [collector_pid], collector_pid
+        )
         print(json.dumps(pid_labels, indent=4))
         for pid, label in pid_labels.items():
             # Add trend of collector process to graph
-            collector_runtimes = quanta_df.filter(
-                pl.col("tgid") == pid
-            )
+            collector_runtimes = quanta_df.filter(pl.col("tgid") == pid)
             self.graph_engine.plot(
                 (
-                    (collector_runtimes.select(UPTIME_TIMESTAMP) / 1_000_000.0) - start_uptime_sec
-                ).to_series().to_list(),
-                (collector_runtimes.select("quanta_run_length_us") / 1_000.0).to_series().to_list(),
+                    (collector_runtimes.select(UPTIME_TIMESTAMP) / 1_000_000.0)
+                    - start_uptime_sec
+                )
+                .to_series()
+                .to_list(),
+                (collector_runtimes.select("quanta_run_length_us") / 1_000.0)
+                .to_series()
+                .to_list(),
                 label="Collector Process" if collector_pid == pid else label[:35],
             )
-        print(f"Total processor time per cpu:\n{quanta_table.per_cpu_total_runtime_sec()}")
+        print(
+            f"Total processor time per cpu:\n{quanta_table.per_cpu_total_runtime_sec()}"
+        )
 
-    def _get_pid_labels(self, pids: list[int], collector_pid: int | None = None) -> Mapping[int, str]:
+    def _get_pid_labels(
+        self, pids: list[int], collector_pid: int | None = None
+    ) -> Mapping[int, str]:
         process_table = self.collection_data.get(ProcessMetadataTable)
         if not process_table:
             return {
@@ -242,7 +275,7 @@ class QuantaRuntimeGraph(CollectionGraph):
                 process_data["pid"].to_list(),
                 process_data["name"].to_list(),
                 process_data["cmdline"].to_list(),
-                strict=True
+                strict=True,
             )
         }
         return {
@@ -252,7 +285,6 @@ class QuantaRuntimeGraph(CollectionGraph):
 
 
 class QuantaQueuedGraph(CollectionGraph):
-
     @classmethod
     def with_graph_engine(cls, graph_engine: GraphEngine) -> CollectionGraph | None:
         quanta_table = graph_engine.collection_data.get(QuantaQueuedTable)
@@ -293,7 +325,9 @@ class QuantaQueuedGraph(CollectionGraph):
         for cpu, quanta_df_group in quanta_df_by_cpu:
             self.graph_engine.scatter(
                 self.collection_data.normalize_uptime_sec(quanta_df_group),
-                (quanta_df_group.select("quanta_queued_time_us") / 1_000.0).to_series().to_list(),
+                (quanta_df_group.select("quanta_queued_time_us") / 1_000.0)
+                .to_series()
+                .to_list(),
                 label=f"CPU {cpu[0]}",
             )
 
@@ -305,23 +339,32 @@ class QuantaQueuedGraph(CollectionGraph):
         collector_pid = self.collection_data.pid
         top_k = quanta_table.top_k_queued_time(k=3)
         print(top_k)
-        pid_labels: Mapping[int, str] = self._get_pid_labels(top_k["pid"].to_list() + [collector_pid], collector_pid)
+        pid_labels: Mapping[int, str] = self._get_pid_labels(
+            top_k["pid"].to_list() + [collector_pid], collector_pid
+        )
         print(json.dumps(pid_labels, indent=4))
         for pid, label in pid_labels.items():
             # Add trend of collector process to graph
-            collector_runtimes = quanta_df.filter(
-                pl.col("tgid") == pid
-            )
+            collector_runtimes = quanta_df.filter(pl.col("tgid") == pid)
             self.graph_engine.plot(
                 (
-                    (collector_runtimes.select(UPTIME_TIMESTAMP) / 1_000_000.0) - start_uptime_sec
-                ).to_series().to_list(),
-                (collector_runtimes.select("quanta_queued_time_us") / 1_000.0).to_series().to_list(),
+                    (collector_runtimes.select(UPTIME_TIMESTAMP) / 1_000_000.0)
+                    - start_uptime_sec
+                )
+                .to_series()
+                .to_list(),
+                (collector_runtimes.select("quanta_queued_time_us") / 1_000.0)
+                .to_series()
+                .to_list(),
                 label="Collector Process" if collector_pid == pid else label[:35],
             )
-        print(f"Total processor time per cpu:\n{quanta_table.per_cpu_total_runtime_sec()}")
+        print(
+            f"Total processor time per cpu:\n{quanta_table.per_cpu_total_runtime_sec()}"
+        )
 
-    def _get_pid_labels(self, pids: list[int], collector_pid: int | None = None) -> Mapping[int, str]:
+    def _get_pid_labels(
+        self, pids: list[int], collector_pid: int | None = None
+    ) -> Mapping[int, str]:
         process_table = self.collection_data.get(ProcessMetadataTable)
         if not process_table:
             return {
@@ -337,7 +380,7 @@ class QuantaQueuedGraph(CollectionGraph):
                 process_data["pid"].to_list(),
                 process_data["name"].to_list(),
                 process_data["cmdline"].to_list(),
-                strict=True
+                strict=True,
             )
         }
         return {

--- a/python/kernmlops/kernmlops_benchmark/__init__.py
+++ b/python/kernmlops/kernmlops_benchmark/__init__.py
@@ -27,7 +27,7 @@ benchmarks: Mapping[str, type[Benchmark]] = {
     MongoDbBenchmark.name(): MongoDbBenchmark,
     LinnosBenchmark.name(): LinnosBenchmark,
     RedisBenchmark.name(): RedisBenchmark,
-    MemcachedBenchmark.name(): MemcachedBenchmark
+    MemcachedBenchmark.name(): MemcachedBenchmark,
 }
 
 BenchmarkConfig = make_dataclass(
@@ -39,7 +39,8 @@ BenchmarkConfig = make_dataclass(
             GenericBenchmarkConfig,
             field(default=GenericBenchmarkConfig()),
         )
-    ] + [
+    ]
+    + [
         (name, ConfigBase, field(default=benchmark.default_config()))
         for name, benchmark in benchmarks.items()
     ],

--- a/python/kernmlops/kernmlops_benchmark/benchmark.py
+++ b/python/kernmlops/kernmlops_benchmark/benchmark.py
@@ -11,149 +11,153 @@ from kernmlops_config import ConfigBase
 from typing_extensions import Protocol
 
 
-def overcommit_convert(inp: Literal["no_change", "heuristic", "never_check", "always_check"]) -> int | None:
-  if inp == "no_change":
-      return None
-  arr = ["heuristic", "never_check", "always_check"]
-  return arr.index(inp)
+def overcommit_convert(
+    inp: Literal["no_change", "heuristic", "never_check", "always_check"],
+) -> int | None:
+    if inp == "no_change":
+        return None
+    arr = ["heuristic", "never_check", "always_check"]
+    return arr.index(inp)
+
 
 @dataclass(frozen=True)
 class GenericBenchmarkConfig(ConfigBase):
-  benchmark: str = "faux"
-  benchmark_dir: str = ""
-  cpus: int = 0
-  skip_clear_page_cache: bool = False
-  transparent_hugepages: Literal["no_change", "always", "madvise", "never"] = "always"
-  overcommit_memory: Literal["no_change", "heuristic", "never_check", "always_check"] = "heuristic"
-  khugepaged_scan_sleep_millis: int | None = None
+    benchmark: str = "faux"
+    benchmark_dir: str = ""
+    cpus: int = 0
+    skip_clear_page_cache: bool = False
+    transparent_hugepages: Literal["no_change", "always", "madvise", "never"] = "always"
+    overcommit_memory: Literal[
+        "no_change", "heuristic", "never_check", "always_check"
+    ] = "heuristic"
+    khugepaged_scan_sleep_millis: int | None = None
 
-  def get_benchmark_dir(self) -> Path:
-    if self.benchmark_dir:
-      return Path(self.benchmark_dir)
-    elif "UNAME" in os.environ:
-      return Path(f"/home/{os.environ['UNAME']}/kernmlops-benchmark")
-    return Path.home() / "kernmlops-benchmark"
+    def get_benchmark_dir(self) -> Path:
+        if self.benchmark_dir:
+            return Path(self.benchmark_dir)
+        elif "UNAME" in os.environ:
+            return Path(f"/home/{os.environ['UNAME']}/kernmlops-benchmark")
+        return Path.home() / "kernmlops-benchmark"
 
-  def generic_setup(self):
-    """This will set pertinent generic settings, should be called after specific benchmark setup."""
-    if not self.skip_clear_page_cache:
-      subprocess.check_call(
-          ["bash", "-c", "sync && echo 3 > /proc/sys/vm/drop_caches"],
-          stdout=subprocess.DEVNULL,
-      )
-    if self.transparent_hugepages != "no_change":
-        subprocess.check_call(
-            [
-              "bash",
-              "-c",
-              f"echo {self.transparent_hugepages} > /sys/kernel/mm/transparent_hugepage/enabled",
-            ],
-            stdout=subprocess.DEVNULL,
-        )
+    def generic_setup(self):
+        """This will set pertinent generic settings, should be called after specific benchmark setup."""
+        if not self.skip_clear_page_cache:
+            subprocess.check_call(
+                ["bash", "-c", "sync && echo 3 > /proc/sys/vm/drop_caches"],
+                stdout=subprocess.DEVNULL,
+            )
+        if self.transparent_hugepages != "no_change":
+            subprocess.check_call(
+                [
+                    "bash",
+                    "-c",
+                    f"echo {self.transparent_hugepages} > /sys/kernel/mm/transparent_hugepage/enabled",
+                ],
+                stdout=subprocess.DEVNULL,
+            )
 
-    overcommit_setting = overcommit_convert(self.overcommit_memory)
-    if overcommit_setting is not None:
-        subprocess.check_call(
-            [
-              "bash",
-              "-c",
-              f"sysctl -w vm.overcommit_memory={overcommit_setting}",
-            ],
-            stdout=subprocess.DEVNULL,
-        )
-    if self.khugepaged_scan_sleep_millis is not None:
-        subprocess.check_call(
-            [
-              "bash",
-              "-c",
-              f"echo {self.khugepaged_scan_sleep_millis} > /sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs",
-            ],
-            stdout=subprocess.DEVNULL,
-        )
-
-
-
+        overcommit_setting = overcommit_convert(self.overcommit_memory)
+        if overcommit_setting is not None:
+            subprocess.check_call(
+                [
+                    "bash",
+                    "-c",
+                    f"sysctl -w vm.overcommit_memory={overcommit_setting}",
+                ],
+                stdout=subprocess.DEVNULL,
+            )
+        if self.khugepaged_scan_sleep_millis is not None:
+            subprocess.check_call(
+                [
+                    "bash",
+                    "-c",
+                    f"echo {self.khugepaged_scan_sleep_millis} > /sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs",
+                ],
+                stdout=subprocess.DEVNULL,
+            )
 
 
 @dataclass(frozen=True)
 class FauxBenchmarkConfig(ConfigBase):
-  pass
+    pass
 
 
 class Benchmark(Protocol):
-  """Runnable benchmark that terminates naturally in finite time."""
+    """Runnable benchmark that terminates naturally in finite time."""
 
-  @classmethod
-  def name(cls) -> str: ...
+    @classmethod
+    def name(cls) -> str: ...
 
-  @classmethod
-  def default_config(cls) -> ConfigBase: ...
+    @classmethod
+    def default_config(cls) -> ConfigBase: ...
 
-  @classmethod
-  def from_config(cls, config: ConfigBase) -> "Benchmark": ...
+    @classmethod
+    def from_config(cls, config: ConfigBase) -> "Benchmark": ...
 
-  def is_configured(self) -> bool:
-    """Returns True if the environment has been setup to run the benchmark."""
-    ...
+    def is_configured(self) -> bool:
+        """Returns True if the environment has been setup to run the benchmark."""
+        ...
 
-  def setup(self) -> None: ...
+    def setup(self) -> None: ...
 
-  def run(self) -> None: ...
+    def run(self) -> None: ...
 
-  def poll(self) -> int | None:
-    """Returns None when benchmark is running, nonzero when crashed."""
-    ...
+    def poll(self) -> int | None:
+        """Returns None when benchmark is running, nonzero when crashed."""
+        ...
 
-  def wait(self) -> None: ...
+    def wait(self) -> None: ...
 
-  def kill(self) -> None: ...
+    def kill(self) -> None: ...
 
-  @classmethod
-  def plot_events(cls, graph_engine: GraphEngine) -> None:
-    """Given a collection of data, plot important events for this benchmark."""
-    ...
+    @classmethod
+    def plot_events(cls, graph_engine: GraphEngine) -> None:
+        """Given a collection of data, plot important events for this benchmark."""
+        ...
 
 
 class FauxBenchmark(Benchmark):
-  """Benchmark that does nothing and allows users to collect the running system's data."""
+    """Benchmark that does nothing and allows users to collect the running system's data."""
 
-  @classmethod
-  def name(cls) -> str:
-    return "faux"
+    @classmethod
+    def name(cls) -> str:
+        return "faux"
 
-  @classmethod
-  def default_config(cls) -> ConfigBase:
-    return FauxBenchmarkConfig()
+    @classmethod
+    def default_config(cls) -> ConfigBase:
+        return FauxBenchmarkConfig()
 
-  @classmethod
-  def from_config(cls, config: ConfigBase) -> "Benchmark":
-    generic_config = cast(GenericBenchmarkConfig, getattr(config, "generic"))
-    faux_config = cast(FauxBenchmarkConfig, getattr(config, cls.name()))
-    return FauxBenchmark(generic_config=generic_config, config=faux_config)
+    @classmethod
+    def from_config(cls, config: ConfigBase) -> "Benchmark":
+        generic_config = cast(GenericBenchmarkConfig, getattr(config, "generic"))
+        faux_config = cast(FauxBenchmarkConfig, getattr(config, cls.name()))
+        return FauxBenchmark(generic_config=generic_config, config=faux_config)
 
-  def __init__(self, *, generic_config: GenericBenchmarkConfig, config: FauxBenchmarkConfig):
-    self.generic_config = generic_config
-    self.config = config
+    def __init__(
+        self, *, generic_config: GenericBenchmarkConfig, config: FauxBenchmarkConfig
+    ):
+        self.generic_config = generic_config
+        self.config = config
 
-  def is_configured(self) -> bool:
-    return True
+    def is_configured(self) -> bool:
+        return True
 
-  def setup(self) -> None:
-    self.generic_config.generic_setup()
+    def setup(self) -> None:
+        self.generic_config.generic_setup()
 
-  def run(self) -> None:
-    print("\nHit Ctrl+C to terminate...")
+    def run(self) -> None:
+        print("\nHit Ctrl+C to terminate...")
 
-  def poll(self) -> int | None:
-    """This benchmark will never self terminate."""
-    return None
+    def poll(self) -> int | None:
+        """This benchmark will never self terminate."""
+        return None
 
-  def wait(self) -> None:
-    pass
+    def wait(self) -> None:
+        pass
 
-  def kill(self) -> None:
-    pass
+    def kill(self) -> None:
+        pass
 
-  @classmethod
-  def plot_events(cls, graph_engine: GraphEngine) -> None:
-    pass
+    @classmethod
+    def plot_events(cls, graph_engine: GraphEngine) -> None:
+        pass

--- a/python/kernmlops/kernmlops_benchmark/errors.py
+++ b/python/kernmlops/kernmlops_benchmark/errors.py
@@ -1,16 +1,21 @@
 """Common benchmarking errors."""
 
+
 class BenchmarkError(Exception):
     pass
+
 
 class BenchmarkNotConfiguredError(BenchmarkError):
     pass
 
+
 class BenchmarkRunningError(BenchmarkError):
     pass
 
+
 class BenchmarkNotRunningError(BenchmarkError):
     pass
+
 
 class BenchmarkNotInCollectionData(BenchmarkError):
     pass

--- a/python/kernmlops/kernmlops_benchmark/gap.py
+++ b/python/kernmlops/kernmlops_benchmark/gap.py
@@ -6,22 +6,21 @@ from typing import Literal, cast
 from data_schema import GraphEngine, demote
 from kernmlops_benchmark.benchmark import Benchmark, GenericBenchmarkConfig
 from kernmlops_benchmark.errors import (
-  BenchmarkNotInCollectionData,
-  BenchmarkNotRunningError,
-  BenchmarkRunningError,
+    BenchmarkNotInCollectionData,
+    BenchmarkNotRunningError,
+    BenchmarkRunningError,
 )
 from kernmlops_config import ConfigBase
 
 
 @dataclass(frozen=True)
 class GapBenchmarkConfig(ConfigBase):
-  gap_benchmark: Literal["pr"] = "pr"
-  gap_benchmark_size: int = 25
-  trials: int = 2
+    gap_benchmark: Literal["pr"] = "pr"
+    gap_benchmark_size: int = 25
+    trials: int = 2
 
 
 class GapBenchmark(Benchmark):
-
     @classmethod
     def name(cls) -> str:
         return "gap"
@@ -36,14 +35,18 @@ class GapBenchmark(Benchmark):
         gap_config = cast(GapBenchmarkConfig, getattr(config, cls.name()))
         return GapBenchmark(generic_config=generic_config, config=gap_config)
 
-    def __init__(self, *, generic_config: GenericBenchmarkConfig, config: GapBenchmarkConfig):
+    def __init__(
+        self, *, generic_config: GenericBenchmarkConfig, config: GapBenchmarkConfig
+    ):
         self.generic_config = generic_config
         self.config = config
         self.benchmark_dir = self.generic_config.get_benchmark_dir() / self.name()
         self.process: subprocess.Popen | None = None
 
     def get_input_file_path(self) -> Path:
-        return Path(self.benchmark_dir / "graphs" / f"kron{self.config.gap_benchmark_size}.sg")
+        return Path(
+            self.benchmark_dir / "graphs" / f"kron{self.config.gap_benchmark_size}.sg"
+        )
 
     def is_configured(self) -> bool:
         return self.benchmark_dir.is_dir()
@@ -52,15 +55,17 @@ class GapBenchmark(Benchmark):
         if self.process is not None:
             raise BenchmarkRunningError()
         if not self.get_input_file_path().is_file():
-          create_graph_process = subprocess.Popen([
-            str(self.benchmark_dir / "converter"),
-            "-m",
-            "-g",
-            f"{self.config.gap_benchmark_size}",
-            "-b",
-            str(self.get_input_file_path()),
-          ])
-          create_graph_process.wait()
+            create_graph_process = subprocess.Popen(
+                [
+                    str(self.benchmark_dir / "converter"),
+                    "-m",
+                    "-g",
+                    f"{self.config.gap_benchmark_size}",
+                    "-b",
+                    str(self.get_input_file_path()),
+                ]
+            )
+            create_graph_process.wait()
         self.generic_config.generic_setup()
 
     def run(self) -> None:

--- a/python/kernmlops/kernmlops_benchmark/linnos.py
+++ b/python/kernmlops/kernmlops_benchmark/linnos.py
@@ -6,9 +6,9 @@ from typing import Literal, cast
 from data_schema import GraphEngine, demote
 from kernmlops_benchmark.benchmark import Benchmark, GenericBenchmarkConfig
 from kernmlops_benchmark.errors import (
-  BenchmarkNotInCollectionData,
-  BenchmarkNotRunningError,
-  BenchmarkRunningError,
+    BenchmarkNotInCollectionData,
+    BenchmarkNotRunningError,
+    BenchmarkRunningError,
 )
 from kernmlops_config import ConfigBase
 
@@ -23,15 +23,16 @@ def _default_traces() -> list[str]:
 
 @dataclass(frozen=True)
 class LinnosBenchmarkConfig(ConfigBase):
-  use_root: bool = False # required for accessing raw devices
-  shuffle_traces: bool = False
-  type: Literal["baseline", "failover"] = "baseline"
-  devices: list[str] = field(default_factory=_default_devices) # devices cannot contain '-'
-  traces: list[str] = field(default_factory=_default_traces)
+    use_root: bool = False  # required for accessing raw devices
+    shuffle_traces: bool = False
+    type: Literal["baseline", "failover"] = "baseline"
+    devices: list[str] = field(
+        default_factory=_default_devices
+    )  # devices cannot contain '-'
+    traces: list[str] = field(default_factory=_default_traces)
 
 
 class LinnosBenchmark(Benchmark):
-
     @classmethod
     def name(cls) -> str:
         return "linnos"
@@ -46,10 +47,14 @@ class LinnosBenchmark(Benchmark):
         linnos_config = cast(LinnosBenchmarkConfig, getattr(config, cls.name()))
         return LinnosBenchmark(generic_config=generic_config, config=linnos_config)
 
-    def __init__(self, *, generic_config: GenericBenchmarkConfig, config: LinnosBenchmarkConfig):
+    def __init__(
+        self, *, generic_config: GenericBenchmarkConfig, config: LinnosBenchmarkConfig
+    ):
         self.generic_config = generic_config
         self.config = config
-        self.benchmark_dir = self.generic_config.get_benchmark_dir() / self.name() / "src" / "linnos"
+        self.benchmark_dir = (
+            self.generic_config.get_benchmark_dir() / self.name() / "src" / "linnos"
+        )
         self.process: subprocess.Popen | None = None
 
     def is_configured(self) -> bool:

--- a/python/kernmlops/kernmlops_benchmark/linux_build.py
+++ b/python/kernmlops/kernmlops_benchmark/linux_build.py
@@ -18,7 +18,6 @@ class LinuxBuildBenchmarkConfig(ConfigBase):
 
 
 class LinuxBuildBenchmark(Benchmark):
-
     @classmethod
     def name(cls) -> str:
         return "linux_build"
@@ -33,7 +32,12 @@ class LinuxBuildBenchmark(Benchmark):
         linux_config = cast(LinuxBuildBenchmarkConfig, getattr(config, cls.name()))
         return LinuxBuildBenchmark(generic_config=generic_config, config=linux_config)
 
-    def __init__(self, *, generic_config: GenericBenchmarkConfig, config: LinuxBuildBenchmarkConfig):
+    def __init__(
+        self,
+        *,
+        generic_config: GenericBenchmarkConfig,
+        config: LinuxBuildBenchmarkConfig,
+    ):
         self.generic_config = generic_config
         self.config = config
         self.benchmark_dir = self.generic_config.get_benchmark_dir() / self.name()
@@ -98,7 +102,15 @@ class LinuxBuildBenchmark(Benchmark):
             return None
 
         graph_engine.plot_event_as_sec(ts_us=file_data.get_first_occurrence_us("make"))
-        graph_engine.plot_event_as_sec(ts_us=file_data.get_last_occurrence_us("bzImage"))
-        graph_engine.plot_event_as_sec(ts_us=file_data.get_last_occurrence_us("vmlinux.bin"))
-        graph_engine.plot_event_as_sec(ts_us=file_data.get_last_occurrence_us("vmlinux.o"))
-        graph_engine.plot_event_as_sec(ts_us=file_data.get_last_occurrence_us("vmlinux"))
+        graph_engine.plot_event_as_sec(
+            ts_us=file_data.get_last_occurrence_us("bzImage")
+        )
+        graph_engine.plot_event_as_sec(
+            ts_us=file_data.get_last_occurrence_us("vmlinux.bin")
+        )
+        graph_engine.plot_event_as_sec(
+            ts_us=file_data.get_last_occurrence_us("vmlinux.o")
+        )
+        graph_engine.plot_event_as_sec(
+            ts_us=file_data.get_last_occurrence_us("vmlinux")
+        )

--- a/python/kernmlops/kernmlops_benchmark/memcached.py
+++ b/python/kernmlops/kernmlops_benchmark/memcached.py
@@ -41,8 +41,8 @@ class MemcachedConfig(ConfigBase):
     sleep: str | None = None
     server_sleep: str | None = None
 
-class MemcachedBenchmark(Benchmark):
 
+class MemcachedBenchmark(Benchmark):
     @classmethod
     def name(cls) -> str:
         return "memcached"
@@ -55,9 +55,13 @@ class MemcachedBenchmark(Benchmark):
     def from_config(cls, config: ConfigBase) -> "Benchmark":
         generic_config = cast(GenericBenchmarkConfig, getattr(config, "generic"))
         memcached_config = cast(MemcachedConfig, getattr(config, cls.name()))
-        return MemcachedBenchmark(generic_config=generic_config, config=memcached_config)
+        return MemcachedBenchmark(
+            generic_config=generic_config, config=memcached_config
+        )
 
-    def __init__(self, *, generic_config: GenericBenchmarkConfig, config: MemcachedConfig):
+    def __init__(
+        self, *, generic_config: GenericBenchmarkConfig, config: MemcachedConfig
+    ):
         self.generic_config = generic_config
         self.config = config
         self.benchmark_dir = self.generic_config.get_benchmark_dir() / "ycsb"
@@ -102,7 +106,7 @@ class MemcachedBenchmark(Benchmark):
         while i < 10 and ping_memcached.returncode != 0:
             time.sleep(1)
             ping_memcached = subprocess.run(set_foo_memcached, shell=True)
-            i+=1
+            i += 1
 
         if ping_memcached.returncode != 0:
             raise BenchmarkError("Memcached Failed To Start")
@@ -123,17 +127,23 @@ class MemcachedBenchmark(Benchmark):
         if delete_foo.returncode != 0:
             raise BenchmarkError("Delete Single Memcached Record Failing")
 
-        server_space : int | float | None = None if self.config.server_sleep is None else timeparse(self.config.server_sleep)
-        if server_space is not None :
+        server_space: int | float | None = (
+            None
+            if self.config.server_sleep is None
+            else timeparse(self.config.server_sleep)
+        )
+        if server_space is not None:
             time.sleep(server_space)
 
-        space : int | float | None = None if self.config.sleep is None else timeparse(self.config.sleep)
+        space: int | float | None = (
+            None if self.config.sleep is None else timeparse(self.config.sleep)
+        )
 
         process: subprocess.Popen | None = None
         for i in range(self.config.repeat):
             if process is not None:
                 process.wait()
-                if space is not None :
+                if space is not None:
                     time.sleep(space)
                 if process.returncode != 0:
                     self.process = process
@@ -142,27 +152,27 @@ class MemcachedBenchmark(Benchmark):
             insert_start = i * self.config.record_count
             # Run loads
             load_memcached = [
-                    "python",
-                    f"{self.benchmark_dir}/YCSB/bin/ycsb",
-                    "load",
-                    "memcached",
-                    "-s",
-                    "-P",
-                    f"{self.benchmark_dir}/YCSB/workloads/workloada",
-                    "-p",
-                    "memcached.hosts=localhost:11211",
-                    "-p",
-                    f"recordcount={self.config.record_count}",
-                    "-p",
-                    f"fieldcount={self.config.field_count}",
-                    "-p",
-                    f"fieldlength={self.config.field_length}",
-                    "-p",
-                    f"minfieldlength={self.config.min_field_length}",
-                    "-p",
-                    f"insertstart={insert_start}",
-                    "-p",
-                    f"fieldlengthdistribution={self.config.field_length_distribution}",
+                "python",
+                f"{self.benchmark_dir}/YCSB/bin/ycsb",
+                "load",
+                "memcached",
+                "-s",
+                "-P",
+                f"{self.benchmark_dir}/YCSB/workloads/workloada",
+                "-p",
+                "memcached.hosts=localhost:11211",
+                "-p",
+                f"recordcount={self.config.record_count}",
+                "-p",
+                f"fieldcount={self.config.field_count}",
+                "-p",
+                f"fieldlength={self.config.field_length}",
+                "-p",
+                f"minfieldlength={self.config.min_field_length}",
+                "-p",
+                f"insertstart={insert_start}",
+                "-p",
+                f"fieldlengthdistribution={self.config.field_length_distribution}",
             ]
             load_memcached = subprocess.run(load_memcached, preexec_fn=demote())
 

--- a/python/kernmlops/kernmlops_benchmark/mongodb.py
+++ b/python/kernmlops/kernmlops_benchmark/mongodb.py
@@ -44,14 +44,15 @@ class MongoDbConfig(ConfigBase):
     server_sleep: str | None = None
     url: str = "mongodb://localhost:27017/"
 
+
 kill_mongod = [
     "killall",
     "-9",
     "mongod",
 ]
 
-class MongoDbBenchmark(Benchmark):
 
+class MongoDbBenchmark(Benchmark):
     @classmethod
     def name(cls) -> str:
         return "mongodb"
@@ -66,7 +67,9 @@ class MongoDbBenchmark(Benchmark):
         mongodb_config = cast(MongoDbConfig, getattr(config, cls.name()))
         return MongoDbBenchmark(generic_config=generic_config, config=mongodb_config)
 
-    def __init__(self, *, generic_config: GenericBenchmarkConfig, config: MongoDbConfig):
+    def __init__(
+        self, *, generic_config: GenericBenchmarkConfig, config: MongoDbConfig
+    ):
         self.generic_config = generic_config
         self.config = config
         self.benchmark_dir = self.generic_config.get_benchmark_dir() / "ycsb"
@@ -111,22 +114,28 @@ class MongoDbBenchmark(Benchmark):
         while i < 10 and ping_mongod is None:
             time.sleep(1)
             ping_mongod = self.ping_mongodb(self.config.url)
-            i+=1
+            i += 1
 
         if ping_mongod is None:
             raise BenchmarkError("MongoDB Failed To Start")
 
-        server_space : int | float | None = None if self.config.server_sleep is None else timeparse(self.config.server_sleep)
-        if server_space is not None :
+        server_space: int | float | None = (
+            None
+            if self.config.server_sleep is None
+            else timeparse(self.config.server_sleep)
+        )
+        if server_space is not None:
             time.sleep(server_space)
 
-        space : int | float | None = None if self.config.sleep is None else timeparse(self.config.sleep)
+        space: int | float | None = (
+            None if self.config.sleep is None else timeparse(self.config.sleep)
+        )
 
         process: subprocess.Popen | None = None
         for i in range(self.config.repeat):
             if process is not None:
                 process.wait()
-                if space is not None :
+                if space is not None:
                     time.sleep(space)
                 if process.returncode != 0:
                     self.process = process
@@ -135,27 +144,27 @@ class MongoDbBenchmark(Benchmark):
             insert_start = i * self.config.record_count
             # Load Server
             load_mongod = [
-                    "python",
-                    f"{self.benchmark_dir}/YCSB/bin/ycsb",
-                    "load",
-                    "mongodb",
-                    "-s",
-                    "-P",
-                    f"{self.benchmark_dir}/YCSB/workloads/workloada",
-                    "-p",
-                    f"mongodb.url={self.config.url}",
-                    "-p",
-                    f"recordcount={self.config.record_count}",
-                    "-p",
-                    f"fieldcount={self.config.field_count}",
-                    "-p",
-                    f"fieldlength={self.config.field_length}",
-                    "-p",
-                    f"minfieldlength={self.config.min_field_length}",
-                    "-p",
-                    f"insertstart={insert_start}",
-                    "-p",
-                    f"fieldlengthdistribution={self.config.field_length_distribution}",
+                "python",
+                f"{self.benchmark_dir}/YCSB/bin/ycsb",
+                "load",
+                "mongodb",
+                "-s",
+                "-P",
+                f"{self.benchmark_dir}/YCSB/workloads/workloada",
+                "-p",
+                f"mongodb.url={self.config.url}",
+                "-p",
+                f"recordcount={self.config.record_count}",
+                "-p",
+                f"fieldcount={self.config.field_count}",
+                "-p",
+                f"fieldlength={self.config.field_length}",
+                "-p",
+                f"minfieldlength={self.config.min_field_length}",
+                "-p",
+                f"insertstart={insert_start}",
+                "-p",
+                f"fieldlengthdistribution={self.config.field_length_distribution}",
             ]
 
             load_mongod = subprocess.Popen(load_mongod, preexec_fn=demote())
@@ -168,50 +177,50 @@ class MongoDbBenchmark(Benchmark):
 
             # Run first benchmark cycle
             run_mongodb = [
-                    f"{self.benchmark_dir}/YCSB/bin/ycsb",
-                    "run",
-                    "mongodb",
-                    "-s",
-                    "-P",
-                    f"{self.benchmark_dir}/YCSB/workloads/workloada",
-                    "-p",
-                    f"operationcount={self.config.operation_count}",
-                    "-p",
-                    f"recordcount={record_count}",
-                    "-p",
-                    "workload=site.ycsb.workloads.CoreWorkload",
-                    "-p",
-                    f"readproportion={self.config.read_proportion}",
-                    "-p",
-                    f"updateproportion={self.config.update_proportion}",
-                    "-p",
-                    f"scanproportion={self.config.scan_proportion}",
-                    "-p",
-                    f"insertproportion={self.config.insert_proportion}",
-                    "-p",
-                    f"readmodifywriteproportion={self.config.rmw_proportion}",
-                    "-p",
-                    f"scanproportion={self.config.scan_proportion}",
-                    "-p",
-                    f"deleteproportion={self.config.delete_proportion}",
-                    "-p",
-                    f"mongodb.url={self.config.url}",
-                    "-p",
-                    f"requestdistribution={self.config.request_distribution}",
-                    "-p",
-                    f"threadcount={self.config.thread_count}",
-                    "-p",
-                    f"target={self.config.target}",
-                    "-p",
-                    f"fieldcount={self.config.field_count}",
-                    "-p",
-                    f"fieldlength={self.config.field_length}",
-                    "-p",
-                    f"minfieldlength={self.config.min_field_length}",
-                    "-p",
-                    f"fieldlengthdistribution={self.config.field_length_distribution}",
-                    "-p",
-                    "mongodb.writeConcern=acknowledged"
+                f"{self.benchmark_dir}/YCSB/bin/ycsb",
+                "run",
+                "mongodb",
+                "-s",
+                "-P",
+                f"{self.benchmark_dir}/YCSB/workloads/workloada",
+                "-p",
+                f"operationcount={self.config.operation_count}",
+                "-p",
+                f"recordcount={record_count}",
+                "-p",
+                "workload=site.ycsb.workloads.CoreWorkload",
+                "-p",
+                f"readproportion={self.config.read_proportion}",
+                "-p",
+                f"updateproportion={self.config.update_proportion}",
+                "-p",
+                f"scanproportion={self.config.scan_proportion}",
+                "-p",
+                f"insertproportion={self.config.insert_proportion}",
+                "-p",
+                f"readmodifywriteproportion={self.config.rmw_proportion}",
+                "-p",
+                f"scanproportion={self.config.scan_proportion}",
+                "-p",
+                f"deleteproportion={self.config.delete_proportion}",
+                "-p",
+                f"mongodb.url={self.config.url}",
+                "-p",
+                f"requestdistribution={self.config.request_distribution}",
+                "-p",
+                f"threadcount={self.config.thread_count}",
+                "-p",
+                f"target={self.config.target}",
+                "-p",
+                f"fieldcount={self.config.field_count}",
+                "-p",
+                f"fieldlength={self.config.field_length}",
+                "-p",
+                f"minfieldlength={self.config.min_field_length}",
+                "-p",
+                f"fieldlengthdistribution={self.config.field_length_distribution}",
+                "-p",
+                "mongodb.writeConcern=acknowledged",
             ]
             process = subprocess.Popen(run_mongodb, preexec_fn=demote())
 
@@ -249,8 +258,8 @@ class MongoDbBenchmark(Benchmark):
         # Drop databases
         client = MongoClient(self.config.url)
         for db in client.list_databases():
-            if db['name'] != 'admin':
-                client.drop_database(db['name'])
+            if db["name"] != "admin":
+                client.drop_database(db["name"])
 
         # Terminate server
         self.server.terminate()

--- a/python/kernmlops/kernmlops_benchmark/redis.py
+++ b/python/kernmlops/kernmlops_benchmark/redis.py
@@ -44,13 +44,14 @@ class RedisConfig(ConfigBase):
     server_sleep: str | None = None
     explicit_purge: bool = False
 
+
 size_redis = [
     "redis-cli",
     "DBSIZE",
 ]
 
-class RedisBenchmark(Benchmark):
 
+class RedisBenchmark(Benchmark):
     @classmethod
     def name(cls) -> str:
         return "redis"
@@ -108,16 +109,22 @@ class RedisBenchmark(Benchmark):
         while i < 10 and ping_redis.returncode != 0:
             time.sleep(1)
             ping_redis = subprocess.run(["redis-cli", "ping"])
-            i+=1
+            i += 1
 
         if ping_redis.returncode != 0:
             raise BenchmarkError("Redis Failed To Start")
 
-        server_space : int | float | None = None if self.config.server_sleep is None else timeparse(self.config.server_sleep)
-        if server_space is not None :
+        server_space: int | float | None = (
+            None
+            if self.config.server_sleep is None
+            else timeparse(self.config.server_sleep)
+        )
+        if server_space is not None:
             time.sleep(server_space)
 
-        space : int | float | None = None if self.config.sleep is None else timeparse(self.config.sleep)
+        space: int | float | None = (
+            None if self.config.sleep is None else timeparse(self.config.sleep)
+        )
         process: subprocess.Popen | None = None
         for out_i in range(self.config.outer_repeat):
             for i in range(self.config.repeat):
@@ -125,7 +132,7 @@ class RedisBenchmark(Benchmark):
                     process.wait()
                     if self.config.explicit_purge:
                         self.purge_server()
-                    if space is not None :
+                    if space is not None:
                         time.sleep(space)
                     if process.returncode != 0:
                         self.process = process
@@ -134,29 +141,29 @@ class RedisBenchmark(Benchmark):
                 insert_start = out_i * self.config.record_count
                 # Load Server
                 load_redis = [
-                        "python",
-                        f"{self.benchmark_dir}/YCSB/bin/ycsb",
-                        "load",
-                        "redis",
-                        "-s",
-                        "-P",
-                        f"{self.benchmark_dir}/YCSB/workloads/workloada",
-                        "-p",
-                        "redis.host=127.0.0.1",
-                        "-p",
-                        "redis.port=6379",
-                        "-p",
-                        f"recordcount={self.config.record_count}",
-                        "-p",
-                        f"fieldcount={self.config.field_count}",
-                        "-p",
-                        f"fieldlength={self.config.field_length}",
-                        "-p",
-                        f"minfieldlength={self.config.min_field_length}",
-                        "-p",
-                        f"insertstart={insert_start}",
-                        "-p",
-                        f"fieldlengthdistribution={self.config.field_length_distribution}",
+                    "python",
+                    f"{self.benchmark_dir}/YCSB/bin/ycsb",
+                    "load",
+                    "redis",
+                    "-s",
+                    "-P",
+                    f"{self.benchmark_dir}/YCSB/workloads/workloada",
+                    "-p",
+                    "redis.host=127.0.0.1",
+                    "-p",
+                    "redis.port=6379",
+                    "-p",
+                    f"recordcount={self.config.record_count}",
+                    "-p",
+                    f"fieldcount={self.config.field_count}",
+                    "-p",
+                    f"fieldlength={self.config.field_length}",
+                    "-p",
+                    f"minfieldlength={self.config.min_field_length}",
+                    "-p",
+                    f"insertstart={insert_start}",
+                    "-p",
+                    f"fieldlengthdistribution={self.config.field_length_distribution}",
                 ]
 
                 if i == 0:
@@ -174,50 +181,50 @@ class RedisBenchmark(Benchmark):
                 record_count = (out_i + 1) * self.config.record_count
 
                 run_redis = [
-                        f"{self.benchmark_dir}/YCSB/bin/ycsb",
-                        "run",
-                        "redis",
-                        "-s",
-                        "-P",
-                        f"{self.benchmark_dir}/YCSB/workloads/workloada",
-                        "-p",
-                        f"operationcount={self.config.operation_count}",
-                        "-p",
-                        f"recordcount={record_count}",
-                        "-p",
-                        "workload=site.ycsb.workloads.CoreWorkload",
-                        "-p",
-                        f"readproportion={self.config.read_proportion}",
-                        "-p",
-                        f"updateproportion={self.config.update_proportion}",
-                        "-p",
-                        f"scanproportion={self.config.scan_proportion}",
-                        "-p",
-                        f"insertproportion={self.config.insert_proportion}",
-                        "-p",
-                        f"readmodifywriteproportion={self.config.rmw_proportion}",
-                        "-p",
-                        f"scanproportion={self.config.scan_proportion}",
-                        "-p",
-                        f"deleteproportion={self.config.delete_proportion}",
-                        "-p",
-                        "redis.host=127.0.0.1",
-                        "-p",
-                        "redis.port=6379",
-                        "-p",
-                        f"requestdistribution={self.config.request_distribution}",
-                        "-p",
-                        f"threadcount={self.config.thread_count}",
-                        "-p",
-                        f"target={self.config.target}",
-                        "-p",
-                        f"fieldcount={self.config.field_count}",
-                        "-p",
-                        f"fieldlength={self.config.field_length}",
-                        "-p",
-                        f"minfieldlength={self.config.min_field_length}",
-                        "-p",
-                        f"fieldlengthdistribution={self.config.field_length_distribution}",
+                    f"{self.benchmark_dir}/YCSB/bin/ycsb",
+                    "run",
+                    "redis",
+                    "-s",
+                    "-P",
+                    f"{self.benchmark_dir}/YCSB/workloads/workloada",
+                    "-p",
+                    f"operationcount={self.config.operation_count}",
+                    "-p",
+                    f"recordcount={record_count}",
+                    "-p",
+                    "workload=site.ycsb.workloads.CoreWorkload",
+                    "-p",
+                    f"readproportion={self.config.read_proportion}",
+                    "-p",
+                    f"updateproportion={self.config.update_proportion}",
+                    "-p",
+                    f"scanproportion={self.config.scan_proportion}",
+                    "-p",
+                    f"insertproportion={self.config.insert_proportion}",
+                    "-p",
+                    f"readmodifywriteproportion={self.config.rmw_proportion}",
+                    "-p",
+                    f"scanproportion={self.config.scan_proportion}",
+                    "-p",
+                    f"deleteproportion={self.config.delete_proportion}",
+                    "-p",
+                    "redis.host=127.0.0.1",
+                    "-p",
+                    "redis.port=6379",
+                    "-p",
+                    f"requestdistribution={self.config.request_distribution}",
+                    "-p",
+                    f"threadcount={self.config.thread_count}",
+                    "-p",
+                    f"target={self.config.target}",
+                    "-p",
+                    f"fieldcount={self.config.field_count}",
+                    "-p",
+                    f"fieldlength={self.config.field_length}",
+                    "-p",
+                    f"minfieldlength={self.config.min_field_length}",
+                    "-p",
+                    f"fieldlengthdistribution={self.config.field_length_distribution}",
                 ]
                 process = subprocess.Popen(run_redis, preexec_fn=demote())
         self.process = process

--- a/python/kernmlops/kernmlops_config/__init__.py
+++ b/python/kernmlops/kernmlops_config/__init__.py
@@ -7,7 +7,6 @@ DEFAULT_CONFIG_FILE = Path("defaults.yaml")
 
 @dataclasses.dataclass(frozen=True)
 class ConfigBase:
-
     def merge(self, config_overrides: Mapping[str, Any]) -> "ConfigBase":
         def _merge(old: MutableMapping[str, Any], new: Mapping[str, Any]) -> None:
             for k, v in new.items():

--- a/scripts/setup-benchmarks/ycsb_runner.py
+++ b/scripts/setup-benchmarks/ycsb_runner.py
@@ -27,93 +27,94 @@ import sys
 
 BASE_URL = "https://github.com/brianfrankcooper/YCSB/tree/master/"
 COMMANDS = {
-    "shell" : {
-        "command"     : "",
-        "description" : "Interactive mode",
-        "main"        : "site.ycsb.CommandLine",
+    "shell": {
+        "command": "",
+        "description": "Interactive mode",
+        "main": "site.ycsb.CommandLine",
     },
-    "load" : {
-        "command"     : "-load",
-        "description" : "Execute the load phase",
-        "main"        : "site.ycsb.Client",
+    "load": {
+        "command": "-load",
+        "description": "Execute the load phase",
+        "main": "site.ycsb.Client",
     },
-    "run" : {
-        "command"     : "-t",
-        "description" : "Execute the transaction phase",
-        "main"        : "site.ycsb.Client",
+    "run": {
+        "command": "-t",
+        "description": "Execute the transaction phase",
+        "main": "site.ycsb.Client",
     },
 }
 
 
 DATABASES = {
-    "accumulo"     : "site.ycsb.db.accumulo.AccumuloClient",
-    "accumulo1.6"     : "site.ycsb.db.accumulo.AccumuloClient",
-    "accumulo1.7"     : "site.ycsb.db.accumulo.AccumuloClient",
-    "accumulo1.8"     : "site.ycsb.db.accumulo.AccumuloClient",
-    "aerospike"    : "site.ycsb.db.AerospikeClient",
-    "arangodb"     : "site.ycsb.db.arangodb.ArangoDBClient",
-    "arangodb3"     : "site.ycsb.db.arangodb.ArangoDBClient",
-    "asynchbase"   : "site.ycsb.db.AsyncHBaseClient",
-    "azurecosmos" : "site.ycsb.db.AzureCosmosClient",
-    "azuretablestorage" : "site.ycsb.db.azuretablestorage.AzureClient",
-    "basic"        : "site.ycsb.BasicDB",
-    "basicts"      : "site.ycsb.BasicTSDB",
+    "accumulo": "site.ycsb.db.accumulo.AccumuloClient",
+    "accumulo1.6": "site.ycsb.db.accumulo.AccumuloClient",
+    "accumulo1.7": "site.ycsb.db.accumulo.AccumuloClient",
+    "accumulo1.8": "site.ycsb.db.accumulo.AccumuloClient",
+    "aerospike": "site.ycsb.db.AerospikeClient",
+    "arangodb": "site.ycsb.db.arangodb.ArangoDBClient",
+    "arangodb3": "site.ycsb.db.arangodb.ArangoDBClient",
+    "asynchbase": "site.ycsb.db.AsyncHBaseClient",
+    "azurecosmos": "site.ycsb.db.AzureCosmosClient",
+    "azuretablestorage": "site.ycsb.db.azuretablestorage.AzureClient",
+    "basic": "site.ycsb.BasicDB",
+    "basicts": "site.ycsb.BasicTSDB",
     "cassandra-cql": "site.ycsb.db.CassandraCQLClient",
     "cassandra2-cql": "site.ycsb.db.CassandraCQLClient",
-    "cloudspanner" : "site.ycsb.db.cloudspanner.CloudSpannerClient",
-    "couchbase"    : "site.ycsb.db.CouchbaseClient",
-    "couchbase2"   : "site.ycsb.db.couchbase2.Couchbase2Client",
-    "crail"        : "site.ycsb.db.crail.CrailClient",
-    "dynamodb"     : "site.ycsb.db.DynamoDBClient",
+    "cloudspanner": "site.ycsb.db.cloudspanner.CloudSpannerClient",
+    "couchbase": "site.ycsb.db.CouchbaseClient",
+    "couchbase2": "site.ycsb.db.couchbase2.Couchbase2Client",
+    "crail": "site.ycsb.db.crail.CrailClient",
+    "dynamodb": "site.ycsb.db.DynamoDBClient",
     "elasticsearch": "site.ycsb.db.ElasticsearchClient",
     "elasticsearch5": "site.ycsb.db.elasticsearch5.ElasticsearchClient",
     "elasticsearch5-rest": "site.ycsb.db.elasticsearch5.ElasticsearchRestClient",
-    "foundationdb" : "site.ycsb.db.foundationdb.FoundationDBClient",
-    "geode"        : "site.ycsb.db.GeodeClient",
-    "googlebigtable"  : "site.ycsb.db.GoogleBigtableClient",
-    "googledatastore" : "site.ycsb.db.GoogleDatastoreClient",
-    "griddb"       : "site.ycsb.db.griddb.GridDBClient",
-    "hbase098"     : "site.ycsb.db.HBaseClient",
-    "hbase10"      : "site.ycsb.db.HBaseClient10",
-    "hbase12"      : "site.ycsb.db.hbase12.HBaseClient12",
-    "hbase14"      : "site.ycsb.db.hbase14.HBaseClient14",
-    "hbase20"      : "site.ycsb.db.hbase20.HBaseClient20",
-    "hypertable"   : "site.ycsb.db.HypertableClient",
-    "ignite"       : "site.ycsb.db.ignite.IgniteClient",
-    "ignite-sql"   : "site.ycsb.db.ignite.IgniteSqlClient",
+    "foundationdb": "site.ycsb.db.foundationdb.FoundationDBClient",
+    "geode": "site.ycsb.db.GeodeClient",
+    "googlebigtable": "site.ycsb.db.GoogleBigtableClient",
+    "googledatastore": "site.ycsb.db.GoogleDatastoreClient",
+    "griddb": "site.ycsb.db.griddb.GridDBClient",
+    "hbase098": "site.ycsb.db.HBaseClient",
+    "hbase10": "site.ycsb.db.HBaseClient10",
+    "hbase12": "site.ycsb.db.hbase12.HBaseClient12",
+    "hbase14": "site.ycsb.db.hbase14.HBaseClient14",
+    "hbase20": "site.ycsb.db.hbase20.HBaseClient20",
+    "hypertable": "site.ycsb.db.HypertableClient",
+    "ignite": "site.ycsb.db.ignite.IgniteClient",
+    "ignite-sql": "site.ycsb.db.ignite.IgniteSqlClient",
     "infinispan-cs": "site.ycsb.db.InfinispanRemoteClient",
-    "infinispan"   : "site.ycsb.db.InfinispanClient",
-    "jdbc"         : "site.ycsb.db.JdbcDBClient",
-    "kudu"         : "site.ycsb.db.KuduYCSBClient",
-    "memcached"    : "site.ycsb.db.MemcachedClient",
-    "maprdb"       : "site.ycsb.db.mapr.MapRDBClient",
-    "maprjsondb"   : "site.ycsb.db.mapr.MapRJSONDBClient",
-    "mongodb"      : "site.ycsb.db.MongoDbClient",
+    "infinispan": "site.ycsb.db.InfinispanClient",
+    "jdbc": "site.ycsb.db.JdbcDBClient",
+    "kudu": "site.ycsb.db.KuduYCSBClient",
+    "memcached": "site.ycsb.db.MemcachedClient",
+    "maprdb": "site.ycsb.db.mapr.MapRDBClient",
+    "maprjsondb": "site.ycsb.db.mapr.MapRJSONDBClient",
+    "mongodb": "site.ycsb.db.MongoDbClient",
     "mongodb-async": "site.ycsb.db.AsyncMongoDbClient",
-    "nosqldb"      : "site.ycsb.db.NoSqlDbClient",
-    "orientdb"     : "site.ycsb.db.OrientDBClient",
-    "postgrenosql" : "site.ycsb.postgrenosql.PostgreNoSQLDBClient",
-    "rados"        : "site.ycsb.db.RadosClient",
-    "redis"        : "site.ycsb.db.RedisClient",
-    "rest"         : "site.ycsb.webservice.rest.RestClient",
-    "riak"         : "site.ycsb.db.riak.RiakKVClient",
-    "rocksdb"      : "site.ycsb.db.rocksdb.RocksDBClient",
-    "s3"           : "site.ycsb.db.S3Client",
-    "solr"         : "site.ycsb.db.solr.SolrClient",
-    "solr6"        : "site.ycsb.db.solr6.SolrClient",
-    "tarantool"    : "site.ycsb.db.TarantoolClient",
-    "tablestore"   : "site.ycsb.db.tablestore.TableStoreClient"
+    "nosqldb": "site.ycsb.db.NoSqlDbClient",
+    "orientdb": "site.ycsb.db.OrientDBClient",
+    "postgrenosql": "site.ycsb.postgrenosql.PostgreNoSQLDBClient",
+    "rados": "site.ycsb.db.RadosClient",
+    "redis": "site.ycsb.db.RedisClient",
+    "rest": "site.ycsb.webservice.rest.RestClient",
+    "riak": "site.ycsb.db.riak.RiakKVClient",
+    "rocksdb": "site.ycsb.db.rocksdb.RocksDBClient",
+    "s3": "site.ycsb.db.S3Client",
+    "solr": "site.ycsb.db.solr.SolrClient",
+    "solr6": "site.ycsb.db.solr6.SolrClient",
+    "tarantool": "site.ycsb.db.TarantoolClient",
+    "tablestore": "site.ycsb.db.tablestore.TableStoreClient",
 }
 
 OPTIONS = {
-    "-P file"        : "Specify workload file",
-    "-p key=value"   : "Override workload property",
-    "-s"             : "Print status to stderr",
-    "-target n"      : "Target ops/sec (default: unthrottled)",
-    "-threads n"     : "Number of client threads (default: 1)",
-    "-cp path"       : "Additional Java classpath entries",
-    "-jvm-args args" : "Additional arguments to the JVM",
+    "-P file": "Specify workload file",
+    "-p key=value": "Override workload property",
+    "-s": "Print status to stderr",
+    "-target n": "Target ops/sec (default: unthrottled)",
+    "-threads n": "Number of client threads (default: 1)",
+    "-cp path": "Additional Java classpath entries",
+    "-jvm-args args": "Additional arguments to the JVM",
 }
+
 
 def usage():
     output = io.StringIO()
@@ -121,24 +122,29 @@ def usage():
 
     print("\nCommands:", file=output)
     for command in sorted(COMMANDS.keys()):
-        print("    %s %s" % (command.ljust(14),
-                            COMMANDS[command]["description"]), file=output)
+        print(
+            "    %s %s" % (command.ljust(14), COMMANDS[command]["description"]),
+            file=output,
+        )
 
     print("\nDatabases:", file=output)
     for db in sorted(DATABASES.keys()):
-        print("    %s %s" % (db.ljust(14), BASE_URL +
-                            db.split("-")[0]), file=output)
+        print("    %s %s" % (db.ljust(14), BASE_URL + db.split("-")[0]), file=output)
 
     print("\nOptions:", file=output)
     for option in sorted(OPTIONS.keys()):
         print("    %s %s" % (option.ljust(14), OPTIONS[option]), file=output)
 
-    print("""\nWorkload Files:
+    print(
+        """\nWorkload Files:
     There are various predefined workloads under workloads/ directory.
     See https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties
-    for the list of workload properties.""", file=output)
+    for the list of workload properties.""",
+        file=output,
+    )
 
     return output.getvalue()
+
 
 # Python 2.6 doesn't have check_output. Add the method as it is in Python 2.7
 # Based on https://github.com/python/cpython/blob/2.7/Lib/subprocess.py#L545
@@ -162,8 +168,8 @@ def check_output(*popenargs, **kwargs):
     ...              stderr=STDOUT)
     'ls: non_existent_file: No such file or directory\n'
     """
-    if 'stdout' in kwargs:
-        raise ValueError('stdout argument not allowed, it will be overridden.')
+    if "stdout" in kwargs:
+        raise ValueError("stdout argument not allowed, it will be overridden.")
     process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
     output, unused_err = process.communicate()
     retcode = process.poll()
@@ -180,18 +186,22 @@ def check_output(*popenargs, **kwargs):
 def debug(message):
     print("[DEBUG] ", message, file=sys.stderr)
 
+
 def warn(message):
     print("[WARN] ", message, file=sys.stderr)
+
 
 def error(message):
     print("[ERROR] ", message, file=sys.stderr)
 
-def find_jars(dir, glob='*.jar'):
+
+def find_jars(dir, glob="*.jar"):
     jars = []
-    for (dirpath, dirnames, filenames) in os.walk(dir):
+    for dirpath, dirnames, filenames in os.walk(dir):
         for filename in fnmatch.filter(filenames, glob):
             jars.append(os.path.join(dirpath, filename))
     return jars
+
 
 def get_ycsb_home():
     dir = os.path.abspath(os.path.dirname(sys.argv[0]))
@@ -199,9 +209,11 @@ def get_ycsb_home():
         dir = os.path.join(dir, os.path.pardir)
     return os.path.abspath(dir)
 
+
 def is_distribution():
     # If there's a top level pom, we're a source checkout. otherwise a dist artifact
     return "pom.xml" not in os.listdir(get_ycsb_home())
+
 
 # Run the maven dependency plugin to get the local jar paths.
 # presumes maven can run, so should only be run on source checkouts
@@ -210,42 +222,65 @@ def is_distribution():
 # Given module is full module name eg. 'core' or 'couchbase-binding'
 def get_classpath_from_maven(module):
     try:
-        debug("Running 'mvn -pl site.ycsb:" + module + " -am package -DskipTests "
-            "dependency:build-classpath -DincludeScope=compile -Dmdep.outputFilterFile=true'")
+        debug(
+            "Running 'mvn -pl site.ycsb:" + module + " -am package -DskipTests "
+            "dependency:build-classpath -DincludeScope=compile -Dmdep.outputFilterFile=true'"
+        )
         os.chdir(get_ycsb_home())
         cwd_output = subprocess.check_output(["pwd"])
         debug(cwd_output)
-        mvn_output = subprocess.check_output(["mvn", "-pl", "site.ycsb:" + module,
-                                "-am", "package", "-DskipTests",
-                                "dependency:build-classpath",
-                                "-DincludeScope=compile",
-                                "-Dmdep.outputFilterFile=true"], universal_newlines=True)
+        mvn_output = subprocess.check_output(
+            [
+                "mvn",
+                "-pl",
+                "site.ycsb:" + module,
+                "-am",
+                "package",
+                "-DskipTests",
+                "dependency:build-classpath",
+                "-DincludeScope=compile",
+                "-Dmdep.outputFilterFile=true",
+            ],
+            universal_newlines=True,
+        )
         line = [x for x in mvn_output.splitlines() if x.startswith("classpath=")][-1:]
-        return line[0][len("classpath="):]
+        return line[0][len("classpath=") :]
     except subprocess.CalledProcessError as err:
-        error("Attempting to generate a classpath from Maven failed "
+        error(
+            "Attempting to generate a classpath from Maven failed "
             f"with return code '{err.returncode}'. The output from "
             "Maven follows, try running "
             "'mvn -DskipTests package dependency:build=classpath' on your "
-            "own and correct errors." + os.linesep + os.linesep + "mvn output:" + os.linesep
-            + err.output)
+            "own and correct errors."
+            + os.linesep
+            + os.linesep
+            + "mvn output:"
+            + os.linesep
+            + err.output
+        )
         sys.exit(err.returncode)
 
 
 def main():
     p = argparse.ArgumentParser(
-            usage=usage(),
-            formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument('-cp', dest='classpath', help="""Additional classpath
+        usage=usage(), formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "-cp",
+        dest="classpath",
+        help="""Additional classpath
                 entries, e.g.  '-cp /tmp/hbase-1.0.1.1/conf'. Will be
-                prepended to the YCSB classpath.""")
-    p.add_argument("-jvm-args", default=[], type=shlex.split,
-                help="""Additional arguments to pass to 'java', e.g.
-                '-Xmx4g'""")
-    p.add_argument("command", choices=sorted(COMMANDS),
-                help="""Command to run.""")
-    p.add_argument("database", choices=sorted(DATABASES),
-                help="""Database to test.""")
+                prepended to the YCSB classpath.""",
+    )
+    p.add_argument(
+        "-jvm-args",
+        default=[],
+        type=shlex.split,
+        help="""Additional arguments to pass to 'java', e.g.
+                '-Xmx4g'""",
+    )
+    p.add_argument("command", choices=sorted(COMMANDS), help="""Command to run.""")
+    p.add_argument("database", choices=sorted(DATABASES), help="""Database to test.""")
     args, remaining = p.parse_known_args()
     ycsb_home = get_ycsb_home()
 
@@ -262,41 +297,55 @@ def main():
     binding = args.database.split("-")[0]
 
     if binding == "accumulo":
-        warn("The 'accumulo' client has been deprecated in favor of version "
+        warn(
+            "The 'accumulo' client has been deprecated in favor of version "
             "specific bindings. This name still maps to the binding for "
             "Accumulo 1.6, which is named 'accumulo-1.6'. This alias will "
-            "be removed in a future YCSB release.")
+            "be removed in a future YCSB release."
+        )
         binding = "accumulo1.6"
 
     if binding == "accumulo1.6":
-        warn("The 'accumulo1.6' client has been deprecated because Accumulo 1.6 "
+        warn(
+            "The 'accumulo1.6' client has been deprecated because Accumulo 1.6 "
             "is EOM. If you are using Accumulo 1.7+ try using the 'accumulo1.7' "
-            "client instead.")
+            "client instead."
+        )
 
     if binding == "cassandra2":
-        warn("The 'cassandra2-cql' client has been deprecated. It has been "
+        warn(
+            "The 'cassandra2-cql' client has been deprecated. It has been "
             "renamed to simply 'cassandra-cql'. This alias will be removed"
-            " in the next YCSB release.")
+            " in the next YCSB release."
+        )
         binding = "cassandra"
 
     if binding == "couchbase":
-        warn("The 'couchbase' client has been deprecated. If you are using "
-            "Couchbase 4.0+ try using the 'couchbase2' client instead.")
+        warn(
+            "The 'couchbase' client has been deprecated. If you are using "
+            "Couchbase 4.0+ try using the 'couchbase2' client instead."
+        )
 
     if binding == "hbase098":
-        warn("The 'hbase098' client has been deprecated because HBase 0.98 "
+        warn(
+            "The 'hbase098' client has been deprecated because HBase 0.98 "
             "is EOM. If you are using HBase 1.2+ try using the 'hbase12' "
-            "client instead.")
+            "client instead."
+        )
 
     if binding == "hbase10":
-        warn("The 'hbase10' client has been deprecated because HBase 1.0 "
+        warn(
+            "The 'hbase10' client has been deprecated because HBase 1.0 "
             "is EOM. If you are using HBase 1.2+ try using the 'hbase12' "
-            "client instead.")
+            "client instead."
+        )
 
     if binding == "arangodb3":
-        warn("The 'arangodb3' client has been deprecated. The binding 'arangodb' "
+        warn(
+            "The 'arangodb3' client has been deprecated. The binding 'arangodb' "
             "now covers every ArangoDB version. This alias will be removed "
-            "in the next YCSB release.")
+            "in the next YCSB release."
+        )
         binding = "arangodb"
 
     if is_distribution():
@@ -308,17 +357,24 @@ def main():
         cp.extend(find_jars(os.path.join(ycsb_home, "lib")))
         cp.extend(find_jars(os.path.join(db_dir, "lib")))
     else:
-        warn("Running against a source checkout. In order to get our runtime "
+        warn(
+            "Running against a source checkout. In order to get our runtime "
             "dependencies we'll have to invoke Maven. Depending on the state "
-            "of your system, this may take ~30-45 seconds")
-        db_location = "core" if (binding == "basic" or binding == "basicts") else binding
-        project = "core" if (binding == "basic" or binding == "basicts") else binding + "-binding"
+            "of your system, this may take ~30-45 seconds"
+        )
+        db_location = (
+            "core" if (binding == "basic" or binding == "basicts") else binding
+        )
+        project = (
+            "core"
+            if (binding == "basic" or binding == "basicts")
+            else binding + "-binding"
+        )
         db_dir = os.path.join(ycsb_home, db_location)
         # goes first so we can rely on side-effect of package
         maven_says = get_classpath_from_maven(project)
         # TODO when we have a version property, skip the glob
-        cp = find_jars(os.path.join(db_dir, "target"),
-                    project + "*.jar")
+        cp = find_jars(os.path.join(db_dir, "target"), project + "*.jar")
         # already in jar:jar:jar form
         cp.append(maven_says)
     cp.insert(0, os.path.join(db_dir, "conf"))
@@ -326,9 +382,12 @@ def main():
     if args.classpath:
         classpath = os.pathsep.join([args.classpath, classpath])
 
-    ycsb_command = ([java] + args.jvm_args +
-                    ["-cp", classpath,
-                    main_classname, "-db", db_classname] + remaining)
+    ycsb_command = (
+        [java]
+        + args.jvm_args
+        + ["-cp", classpath, main_classname, "-db", db_classname]
+        + remaining
+    )
     if command:
         ycsb_command.append(command)
     print(" ".join(ycsb_command), file=sys.stderr)
@@ -336,10 +395,11 @@ def main():
         return subprocess.call(ycsb_command)
     except OSError as e:
         if e.errno == errno.ENOENT:
-            error('Command failed. Is java installed and on your PATH?')
+            error("Command failed. Is java installed and on your PATH?")
             return 1
         else:
             raise
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Currently `make format` does some checks, but doesn't actually format code. This adds an invocation of `ruff format` and also includes it in our pre-commit hooks.